### PR TITLE
Be able to perform unhandled effects

### DIFF
--- a/lib/miou.mli
+++ b/lib/miou.mli
@@ -782,6 +782,7 @@ val cancel : 'a t -> unit
     which should not affect the opportunity for other concurrent tasks to run.
 *)
 
+type handler = { handler: 'a 'b. ('a -> 'b) -> 'a -> 'b } [@@unboxed]
 (** {2 Composition.}
 
     It is possible to compose Miou with a library that also generates effects.
@@ -825,7 +826,6 @@ val cancel : 'a t -> unit
     the effect will be produced only as soon as the said task has its execution
     slot.
 *)
-type handler = { handler: 'a 'b. ('a -> 'b) -> 'a -> 'b } [@@unboxed]
 
 val run :
      ?quanta:int

--- a/lib/miou.mli
+++ b/lib/miou.mli
@@ -613,7 +613,6 @@ val task : 'a syscall -> (unit -> unit) -> continue
     represented by the given [syscall]. *)
 
 type events = { select: unit -> continue list; interrupt: unit -> unit }
-type handler = { handler: 'a 'b. ('a -> 'b) -> 'a -> 'b } [@@unboxed]
 
 val is_pending : 'a syscall -> bool
 (** [is_pending syscall] checks the status of the suspension point. A suspension
@@ -782,6 +781,51 @@ val cancel : 'a t -> unit
     a certain amount of time (the time it takes for the domains to synchronise)
     which should not affect the opportunity for other concurrent tasks to run.
 *)
+
+(** {2 Composition.}
+
+    It is possible to compose Miou with a library that also generates effects.
+    The user can compose in 2 ways:
+    - simply apply his/her effect manager with its function in Miou
+      [Miou.call{,_cc} @@ fun () -> handler fn ()]
+    - inform Miou of an effect handler that should comply with the {b "quanta"
+      rule}
+
+    Remember that Miou suspends a task as soon as it emits an effect. The second
+    case can be interesting in order to always ensure the availability of the
+    application regardless effect handlers. Here's a basic example of how to
+    compose.
+
+    {[
+      type _ Effect.t += Foo : unit Effect.t
+
+      let handler fn v =
+        let open Effect.Deep in
+        let retc = Fun.id and exnc = raise in
+        let effc : type c. c Effect.t -> ((c, 'a) continuation -> 'b) option =
+          function Foo -> Some (fun k -> continue k ())
+                 | _ -> None in
+        match_with fn v { retc; exnc; effc; }
+
+      let () = Miou.run ~handler:{ Miou.handler } @@ fun () ->
+        let prm = Miou.call @@ fun () -> Effect.perform Foo in
+        Miou.await_exn prm
+    ]}
+
+    The user can also compose several effects managers:
+
+    {[
+      # let compose { Miou.handler= a } { Miou.handler= b } =
+        { Miou.handler= fun fn v -> (a (b fn)) v } ;;
+      val compose : Miou.handler -> Miou.handler -> Miou.handler = <fun>
+    ]}
+
+    {b NOTE}: We want to reiterate that such a composition implies that the
+    effect will not be executed {i immediately}: the task will be suspended and
+    the effect will be produced only as soon as the said task has its execution
+    slot.
+*)
+type handler = { handler: 'a 'b. ('a -> 'b) -> 'a -> 'b } [@@unboxed]
 
 val run :
      ?quanta:int

--- a/lib/miou.mli
+++ b/lib/miou.mli
@@ -613,6 +613,7 @@ val task : 'a syscall -> (unit -> unit) -> continue
     represented by the given [syscall]. *)
 
 type events = { select: unit -> continue list; interrupt: unit -> unit }
+type handler = { handler: 'a 'b. ('a -> 'b) -> 'a -> 'b } [@@unboxed]
 
 val is_pending : 'a syscall -> bool
 (** [is_pending syscall] checks the status of the suspension point. A suspension
@@ -787,5 +788,6 @@ val run :
   -> ?events:(Domain.Uid.t -> events)
   -> ?g:Random.State.t
   -> ?domains:int
+  -> ?handler:handler
   -> (unit -> 'a)
   -> 'a

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -3,6 +3,7 @@ type ('a, 'b) continuation = ('a, 'b) Effect.Shallow.continuation
 type 'a t =
   | Finished of ('a, exn) result
   | Suspended : ('a, 'b) continuation * 'a Effect.t -> 'b t
+  | Unhandled : ('a, 'b) continuation * 'a -> 'b t
 
 let effc eff k = Suspended (k, eff)
 
@@ -36,6 +37,9 @@ let discontinue_with : ('c, 'a) continuation -> exn -> 'a t =
 let suspended_with : ('c, 'a) continuation -> 'c Effect.t -> 'a t =
  fun k e -> Suspended (k, e)
 
+let unhandled_with : ('c, 'a) continuation -> 'c -> 'a t =
+ fun k v -> Unhandled (k, v)
+
 let pure res = Finished res
 
 let make k v =
@@ -47,6 +51,7 @@ type 'a step =
   | Fail of exn
   | Intr
   | Cont : 'a Effect.t -> 'a step
+  | None : 'a Effect.t -> 'a step
   | Yield : unit step
 
 type ('a, 'b) k = ('a step -> 'b t) -> 'a Effect.t -> 'b t
@@ -55,6 +60,7 @@ type perform = { perform: 'a 'b. ('a, 'b) k } [@@unboxed]
 let once : type a. perform:perform -> a t -> a t =
  fun ~perform -> function
   | Finished _ as finished -> finished
+  | Unhandled (fn, v) -> continue_with fn v
   | Suspended (fn, e) as state ->
       let k : type c. (c, a) continuation -> c step -> a t =
        fun fn -> function
@@ -62,6 +68,9 @@ let once : type a. perform:perform -> a t -> a t =
         | Fail exn -> discontinue_with fn exn
         | Intr -> state
         | Cont e -> suspended_with fn e
+        | None eff ->
+            let v = Effect.perform eff in
+            unhandled_with fn v
         | Yield -> continue_with fn ()
       in
       perform.perform (k fn) e
@@ -80,15 +89,22 @@ let run : type a. quanta:int -> perform:perform -> a t -> a t =
     | Send v -> continue_with fn v
     | Fail e -> discontinue_with fn e
     | Cont e -> suspended_with fn e
+    | None e ->
+        let v = Effect.perform e in
+        unhandled_with fn v
     | Intr -> raise_notrace Break
     | Yield -> raise_notrace (Yield (continue_with fn ()))
   in
   let quanta = ref quanta and state = ref state in
   try
     while !quanta > 0 && is_finished !state = false do
-      let (Suspended (fn, e)) = !state in
-      state := perform.perform (k fn) e;
-      quanta := !quanta - 1
+      match !state with
+      | Suspended (fn, e) ->
+          state := perform.perform (k fn) e;
+          quanta := !quanta - 1
+      | Unhandled (fn, v) ->
+          state := continue_with fn v;
+          quanta := !quanta - 1
     done;
     !state
   with
@@ -102,3 +118,4 @@ let run : type a. quanta:int -> perform:perform -> a t -> a t =
 let fail ~exn = function
   | Finished _ -> Finished (Error exn)
   | Suspended (k, _) -> discontinue_with k exn
+  | Unhandled (k, _) -> discontinue_with k exn

--- a/lib/state.mli
+++ b/lib/state.mli
@@ -76,6 +76,7 @@ type ('a, 'b) continuation
 type 'a t = private
   | Finished of ('a, exn) result
   | Suspended : ('a, 'b) continuation * 'a Effect.t -> 'b t
+  | Unhandled : ('a, 'b) continuation * 'a -> 'b t
 
 val make : ('a -> 'b) -> 'a -> 'b t
 (** [make fn value] makes a new {i function state} by executing the function
@@ -99,6 +100,7 @@ type 'a step =
   | Fail of exn
   | Intr
   | Cont : 'a Effect.t -> 'a step
+  | None : 'a Effect.t -> 'a step
   | Yield : unit step
 
 type ('a, 'b) k = ('a step -> 'b t) -> 'a Effect.t -> 'b t

--- a/test/core/core.t
+++ b/test/core/core.t
@@ -44,3 +44,4 @@
   Fatal error: exception Miou.Still_has_children
   [2]
   $ ./t25.exe
+  $ ./t28.exe

--- a/test/core/dune
+++ b/test/core/dune
@@ -128,6 +128,11 @@
  (modules t27)
  (libraries miou))
 
+(executable
+ (name t28)
+ (modules t28)
+ (libraries miou))
+
 (cram
  (package miou)
  (deps
@@ -155,4 +160,5 @@
   t22.exe
   t23.exe
   t24.exe
-  t25.exe))
+  t25.exe
+  t28.exe))

--- a/test/core/t28.ml
+++ b/test/core/t28.ml
@@ -1,0 +1,18 @@
+type _ Effect.t += Foo : unit Effect.t
+
+let prgm () =
+  let prm = Miou.call_cc @@ fun () -> Effect.perform Foo in
+  Miou.await_exn prm
+
+let handler fn v =
+  let open Effect.Deep in
+  let retc = Fun.id in
+  let exnc = raise in
+  let effc : type c. c Effect.t -> ((c, 'a) continuation -> 'b) option =
+    function
+    | Foo -> Some (fun k -> continue k ())
+    | _ -> None
+  in
+  match_with fn v { retc; exnc; effc }
+
+let () = handler (fun () -> Miou.run prgm) ()

--- a/test/core/t28.ml
+++ b/test/core/t28.ml
@@ -4,7 +4,7 @@ let prgm () =
   let prm = Miou.call @@ fun () -> Effect.perform Foo in
   Miou.await_exn prm
 
-let handler fn v =
+let handler_foo fn v =
   let open Effect.Deep in
   let retc = Fun.id in
   let exnc = raise in
@@ -15,4 +15,36 @@ let handler fn v =
   in
   match_with fn v { retc; exnc; effc }
 
-let () = handler (fun () -> Miou.run ~handler:{ Miou.handler } prgm) ()
+let () =
+  Miou.run ~handler:{ Miou.handler= handler_foo } @@ fun () ->
+  let prm = Miou.call @@ fun () -> Effect.perform Foo in
+  Miou.await_exn prm
+
+let () =
+  Miou.run ~handler:{ Miou.handler= handler_foo } @@ fun () ->
+  let prm = Miou.call_cc @@ fun () -> Effect.perform Foo in
+  Miou.await_exn prm
+
+type _ Effect.t += Bar : unit Effect.t
+
+let handler_bar fn v =
+  let open Effect.Deep in
+  let retc = Fun.id in
+  let exnc = raise in
+  let effc : type c. c Effect.t -> ((c, 'a) continuation -> 'b) option =
+    function
+    | Bar -> Some (fun k -> continue k ())
+    | _ -> None
+  in
+  match_with fn v { retc; exnc; effc }
+
+let ( <.> ) { Miou.handler= foo } { Miou.handler= bar } =
+  { Miou.handler= (fun fn v -> (foo (bar fn)) v) }
+
+let () =
+  let foo = { Miou.handler= handler_foo } in
+  let bar = { Miou.handler= handler_bar } in
+  Miou.run ~handler:(foo <.> bar) @@ fun () ->
+  let prm0 = Miou.call @@ fun () -> Effect.perform Foo in
+  let prm1 = Miou.call @@ fun () -> Effect.perform Bar in
+  Miou.await_exn prm0; Miou.await_exn prm1

--- a/test/core/t28.ml
+++ b/test/core/t28.ml
@@ -1,7 +1,7 @@
 type _ Effect.t += Foo : unit Effect.t
 
 let prgm () =
-  let prm = Miou.call_cc @@ fun () -> Effect.perform Foo in
+  let prm = Miou.call @@ fun () -> Effect.perform Foo in
   Miou.await_exn prm
 
 let handler fn v =
@@ -15,4 +15,4 @@ let handler fn v =
   in
   match_with fn v { retc; exnc; effc }
 
-let () = handler (fun () -> Miou.run prgm) ()
+let () = handler (fun () -> Miou.run ~handler:{ Miou.handler } prgm) ()


### PR DESCRIPTION
Currently, this PR tries to fix the issue #10: what Miou should do when we catch another effect. I did a try with this code:
```ocaml
type _ Effect.t += Foo : unit Effect.t

let prgm () =
  let prm = Miou.call_cc @@ fun () -> Effect.perform Foo in
  Miou.await_exn prm

let handler fn v =
  let open Effect.Deep in
  let retc = Fun.id in
  let exnc = raise in
  let effc : type c. c Effect.t -> ((c, 'a) continuation -> 'b) option =
    function
    | Foo -> Some (fun k -> continue k ())
    | _ -> None
  in
  match_with fn v { retc; exnc; effc }

let () = handler (fun () -> Miou.run prgm) ()
```

So we can plug an other handler on top of Miou which handle our effects. However, we keep the same rule about our "quanta": a program is suspended when it emits one effect (even if the effect is not handled by Miou). The current issue is about parallel task. Indeed, the handler is only well know by `dom0` but if we use `Miou.call`, we will get an exception. We can figure out about an optional argument passed by `Miou.run` which will "protect" tasks with our handler on other domains.

/cc @patricoferris (who asking) @hannesm (who is interested by that)