### PR TITLE
Add Miou_unix.write_string

### DIFF
--- a/lib/miou_unix.ml
+++ b/lib/miou_unix.ml
@@ -139,6 +139,9 @@ let rec write ({ fd; non_blocking } as file_descr) str off len =
     in
     blocking_write fd; go ()
 
+let write_string fd str =
+  write fd str 0 (String.length str)
+
 let rec accept ?cloexec ({ fd; non_blocking } as file_descr) =
   if non_blocking then (
     match Unix.accept ?cloexec fd with

--- a/lib/miou_unix.mli
+++ b/lib/miou_unix.mli
@@ -38,8 +38,11 @@ val read : file_descr -> bytes -> int -> int -> int
     [off]. Return the number of bytes actually read. *)
 
 val write : file_descr -> string -> int -> int -> unit
-(** [write fd str ~off ~len] writes [len] bytes starting at [off] from [str] on
+(** [write fd str off len] writes [len] bytes starting at [off] from [str] on
     [fd]. *)
+
+val write_string : file_descr -> string -> unit
+(** [write fd str] writes [str] bytes on [fd]. *)
 
 val close : file_descr -> unit
 (** [close fd] closes properly the given [fd]. *)


### PR DESCRIPTION
Similarly to `Stdlib.output_string` this function is a higher-level function for `Miou_unix.write` except the offset and length do not have to be provided and are instead calculated to take the whole string.