### PR TITLE
Rename `Miou.call_cc` to `Miou.async`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ technical debt that these bring).
 
 There are 2 ways of creating a task:
 - it can run concurrently with other tasks and execute on the domain in which it
-  was created (see `Miou.call_cc`)
+  was created (see `Miou.async`)
 - it can run in parallel with other tasks and be executed on **another** domain
   (see `Miou.call`)
 
@@ -56,7 +56,7 @@ The first rule to follow is that the user must wait for all the tasks he/she has
 created. If they don't, Miou raises an exception: `Still_has_children`:
 ```ocaml
 let () = Miou.run @@ fun () ->
-  ignore (Miou.call_cc @@ fun () -> 42)
+  ignore (Miou.async @@ fun () -> 42)
 Exception: Miou.Still_has_children
 ```
 
@@ -64,7 +64,7 @@ The user must therefore take care to use `Miou.await` for all the tasks
 (concurrent and parallel) that he/she has created:
 ```ocaml
 let () = Miou.run @@ fun () ->
-  let p0 = Miou.call_cc @@ fun () -> 42 in
+  let p0 = Miou.async @@ fun () -> 42 in
   Miou.await_exn p0
 ```
 
@@ -73,8 +73,8 @@ let () = Miou.run @@ fun () ->
 A task can only be awaited by the person who created it.
 ```ocaml
 let () = Miou.run @@ fun () ->
-  let p0 = Miou.call_cc @@ fun () -> 42 in
-  let p1 = Miou.call_cc @@ fun () -> Miou.await_exn p0 in
+  let p0 = Miou.async @@ fun () -> 42 in
+  let p1 = Miou.async @@ fun () -> Miou.await_exn p0 in
   Miou.await_exn p1
 Esxception: Miou.Not_a_child
 ```
@@ -94,8 +94,8 @@ If a task fails (with an exception), all its sub-tasks also end.
 
 ```ocaml
 let prgm () = Miouu.run @@ fun () ->
-  let p = Miou.call_cc @@ fun () ->
-    let q = Miou.call_cc @@ fun () -> sleep 1. in
+  let p = Miou.async @@ fun () ->
+    let q = Miou.async @@ fun () -> sleep 1. in
     raise (Failure "p") in
   Miou.await p
 
@@ -120,7 +120,7 @@ termination of all its children.
 
 ```ocaml
 let () = Miou.run @@ fun () ->
-  Miou.cancel (Miou.call_cc @@ fun () -> 42)
+  Miou.cancel (Miou.async @@ fun () -> 42)
 ```
 
 This code shows that if it is not possible to `ignore` the result of a task, it
@@ -132,8 +132,8 @@ Tasks are taken randomly. That is to say that this code could return 1 as 2.
 ```ocaml
 let prgm () =
   Miou.run @@ fun () ->
-  let a = Miou.call_cc (Fun.const 1) in
-  let b = Miou.call_cc (Fun.const 2) in
+  let a = Miou.async (Fun.const 1) in
+  let b = Miou.async (Fun.const 2) in
   Miou.await_first [ a; b ]
 
 let rec until_its n =

--- a/book/src/echo.md
+++ b/book/src/echo.md
@@ -43,7 +43,7 @@ let server () =
   while true do
     clean_up orphans;
     let client, _ = Miou_unix.accept socket in
-    ignore (Miou.call_cc ~orphans (fun () -> echo client))
+    ignore (Miou.async ~orphans (fun () -> echo client))
   done;
   Miou_unix.close socket
 
@@ -78,12 +78,12 @@ servers in parallel, each handling several clients concurrently.
 To distribute the implementation of our server across multiple domains, we'll
 use `Miou.parallel`. We won't forget to involve `dom0` (referring to our rule
 where `dom0` would never be assigned a task from other domain) via
-`Miou.call_cc`:
+`Miou.async`:
 ```ocaml
 let () = Miou_unix.run @@ fun () ->
   let domains = Stdlib.Domain.recommended_domain_count () - 1 in
   let domains = List.init domains (Fun.const ()) in
-  let prm = Miou.call_cc server in
+  let prm = Miou.async server in
   Miou.await prm :: Miou.parallel server domains
   |> List.iter @@ function
   | Ok () -> ()
@@ -176,7 +176,7 @@ let server () =
   while true do
     clean_up orphans;
     let client, _ = Miou_unix.Ownership.accept socket in
-    ignore (Miou.call_cc
+    ignore (Miou.async
       ~give:[ Miou_unix.Ownership.resource client ]
       ~orphans (fun () -> echo client))
   done;

--- a/book/src/sleepers.md
+++ b/book/src/sleepers.md
@@ -36,8 +36,8 @@ the one we need to implement.
 ```ocaml
 let program () =
   Chat.run @@ fun () ->
-  let a = Miou.call_cc @@ fun () -> Chat.sleep 1. in
-  let b = Miou.call_cc @@ fun () -> Chat.sleep 2. in
+  let a = Miou.async @@ fun () -> Chat.sleep 1. in
+  let b = Miou.async @@ fun () -> Chat.sleep 2. in
   Miou.await_all [ a; b ]
   |> List.iter @@ function
   | Ok () -> ()
@@ -201,7 +201,7 @@ let select ~block:_ _ =
   remove_and_signal_older sleepers []
 ```
 
-We can now safely replace our `Miou.call_cc` with `Miou.call`. We know that each
+We can now safely replace our `Miou.async` with `Miou.call`. We know that each
 task will have its own `sleepers`, and there will be no illegal access between
 domains.
 

--- a/lib/miou.ml
+++ b/lib/miou.ml
@@ -1034,7 +1034,7 @@ module Ownership = struct
         | exception _ -> Miou_sequence.remove node)
 end
 
-let call_cc ?(give = []) ?orphans fn =
+let async ?(give = []) ?orphans fn =
   let prm = Effect.perform (Spawn (Concurrent, false, give, fn)) in
   Logs.debug (fun m -> m "%a spawned" Promise.pp prm);
   Option.iter (fun s -> Miou_sequence.(add Left) s prm) orphans;
@@ -1123,7 +1123,7 @@ let await_one prms =
     in
     try_attach_all [] prms
   in
-  let prm = call_cc choose in
+  let prm = async choose in
   miou_assert (await_exn prm);
   match Computation.await_exn c with
   | Ok value -> Ok value
@@ -1198,7 +1198,7 @@ let await_first prms =
     in
     try_attach_all [] prms
   in
-  let prm = call_cc choose in
+  let prm = async choose in
   miou_assert (await_exn prm);
   match Computation.await_exn c with
   | Ok value -> Ok value

--- a/merkle/main_p.ml
+++ b/merkle/main_p.ml
@@ -34,7 +34,7 @@ let rec hash_of_tree filename =
 
 and perform = function
   | `Dir, filename ->
-      Miou.call_cc @@ fun () ->
+      Miou.async @@ fun () ->
       let name = Filename.basename filename in
       let hash = hash_of_tree filename in
       Fmt.str "40000 %s\000%s" name (Hash.to_raw_string hash)

--- a/philosophers/main.ml
+++ b/philosophers/main.ml
@@ -88,7 +88,7 @@ let () =
   let sem = Array.init 5 (fun _ -> Semaphore.create 1) in
   let state = Array.init 5 (fun _ -> Thinking) in
   let sleep =
-    Miou.call_cc @@ fun () ->
+    Miou.async @@ fun () ->
     Miou_unix.sleep (Float.of_int ts);
     Array.iter Semaphore.release sem
   in
@@ -96,7 +96,7 @@ let () =
     List.init (Stdlib.Domain.recommended_domain_count () - 1) Fun.id
   in
   let philosophers =
-    Miou.call_cc @@ fun () ->
+    Miou.async @@ fun () ->
     ignore (Miou.parallel (philosopher sem state) philosophers)
   in
   Miou.await_first [ philosophers; sleep ] |> ignore

--- a/queue/main.ml
+++ b/queue/main.ml
@@ -60,7 +60,7 @@ let perform = function
 let () =
   Miou.run @@ fun () ->
   let t0 = Bounded_stream.create 20 0 and t1 = Bounded_stream.create 30 0 in
-  let prm = Miou.call_cc @@ fun () -> consume t1 0 8000 in
+  let prm = Miou.async @@ fun () -> consume t1 0 8000 in
   let results =
     Miou.await prm
     :: Miou.parallel perform

--- a/tutorials/echo/echo.mld
+++ b/tutorials/echo/echo.mld
@@ -65,18 +65,18 @@ So we're going to give Miou the ability to suspend our [handler] in order to
 check whether {!val:Miou_unix.accept} is also waiting or whether a connection
 has just arrived.
 
-To specify an asynchronous task with Miou, we use {!val:Miou.call_cc}:
+To specify an asynchronous task with Miou, we use {!val:Miou.async}:
 
 {[
 let server sockaddr =
   let rec go prms fd =
     let fd', sockaddr = Miou_unix.accept fd in
-    let prm = Miou.call_cc (handler fd') in
+    let prm = Miou.async (handler fd') in
     go (prm :: prms) fd in
   go [] (listen sockaddr)
 ]}
 
-Using {!val:Miou.call_cc} returns a "promise". It's a kind of {i witness} for
+Using {!val:Miou.async} returns a "promise". It's a kind of {i witness} for
 our task that lets us know the status of it:
 - whether it is running
 - whether it has finished successfully
@@ -88,7 +88,7 @@ It is possible to manipulate this promise and wait for our task to finish:
 let server sockaddr =
   let rec go fd =
     let fd', sockaddr = Miou_unix.accept fd in
-    let prm = Miou.call_cc (handler fd') in
+    let prm = Miou.async (handler fd') in
     ignore (Miou.await_exn prm);
     go fd in
   go (listen sockaddr)
@@ -131,7 +131,7 @@ let server sockaddr =
   let rec go orphans fd =
     clean_up orphans;
     let fd', sockaddr = Miou_unix.accept fd in
-    let _ = Miou.call_cc ~orphans (handler fd') in
+    let _ = Miou.async ~orphans (handler fd') in
     go orphans fd in
   go (Miou.orphans ()) (listen sockaddr)
 ]}
@@ -159,7 +159,7 @@ that still causes problems.
 {2 Parallelism.}
 
 One of the big advantages of Miou is that it is easy to consider the
-parallelisation of a task. In this case, {!val:Miou.call_cc} can easily be
+parallelisation of a task. In this case, {!val:Miou.async} can easily be
 replaced by {!val:Miou.call}.
 
 {[
@@ -167,7 +167,7 @@ let server sockaddr =
   let rec go orphans fd =
     clean_up orphans;
     let fd', sockaddr = Miou_unix.accept fd in
-    let _ = Miou.call_cc ~orphans (handler fd') in
+    let _ = Miou.async ~orphans (handler fd') in
     go orphans fd in
   go (Miou.orphans ()) (listen sockaddr)
 ]}
@@ -186,14 +186,14 @@ let server sockaddr =
   let rec go orphans fd =
     clean_up orphans;
     let fd', sockaddr = Miou_unix.accept fd in
-    let _ = Miou.call_cc ~orphans (handler fd') in
+    let _ = Miou.async ~orphans (handler fd') in
     go orphans fd in
   go (Miou.orphans ()) (listen sockaddr)
 
 let addr = Unix.ADDR_INET (Unix.inet_addr_loopback, 9000)
 
 let () = Miou.run @@ fun () ->
-  let prm = Miou.call_cc @@ fun () -> server addr in
+  let prm = Miou.async @@ fun () -> server addr in
   Miou.parallel server
     (List.init (Miou.Domain.count ()) (Fun.const addr))
   |> List.iter (function Ok () -> () | Error exn -> raise exn);

--- a/tutorials/echo/main.ml
+++ b/tutorials/echo/main.ml
@@ -43,8 +43,8 @@ let accept_or_stop v fd =
   match
     Miou.await_first
       [
-        Miou.call_cc (fun () -> stop v; raise Stop)
-      ; Miou.call_cc ~give:[ Miou_unix.Ownership.resource fd ] accept
+        Miou.async (fun () -> stop v; raise Stop)
+      ; Miou.async ~give:[ Miou_unix.Ownership.resource fd ] accept
       ]
   with
   | Error Stop -> `Stop
@@ -91,6 +91,6 @@ let () =
   let v = (Miou.Mutex.create (), Miou.Condition.create (), ref false) in
   ignore (Miou.sys_signal Sys.sigint (Sys.Signal_handle (stop v)));
   let servers = List.init 3 (Fun.const (v, localhost_3000)) in
-  let prm = Miou.call_cc @@ fun () -> server (v, localhost_3000) in
+  let prm = Miou.async @@ fun () -> server (v, localhost_3000) in
   ignore (Miou.parallel server servers);
   Miou.await_exn prm

--- a/tutorials/sleepers/sleepers.mld
+++ b/tutorials/sleepers/sleepers.mld
@@ -5,7 +5,7 @@ with {i blocking} operations. For the example, we're going to implement the
 sleepers. [Unix.sleepf] is a blocking operation. The fundamental problem with
 Miou is that it performs operations in the background (scheduling). So using a
 blocking operation with Miou prevents it from managing other tasks
-concurrently (manage tasks entered with {!val:Miou.call_cc}) or in parallel
+concurrently (manage tasks entered with {!val:Miou.async}) or in parallel
 (wait for parallel process tasks introduced by {!val:Miou.call}). 
 
 As stated in the documentation, and this is a fundamental rule:
@@ -28,8 +28,8 @@ open Miou
 
 let program () =
   Miou.run @@ fun () ->
-  let a = Miou.call_cc (fun () -> sleep 1.) in
-  let b = Miou.call_cc (fun () -> sleep 2.) in
+  let a = Miou.async (fun () -> sleep 1.) in
+  let b = Miou.async (fun () -> sleep 2.) in
   Miou.await_all [ a; b ]
   |> List.iter @@ function Ok () -> () | Error exn -> raise exn
 
@@ -155,8 +155,8 @@ we can use them:
 {[
 let prgm () =
   Miou.run ~events @@ fun () ->
-  let a = Miou.call_cc (fun () -> sleep 1.) in
-  let b = Miou.call_cc (fun () -> sleep 2.) in
+  let a = Miou.async (fun () -> sleep 1.) in
+  let b = Miou.async (fun () -> sleep 2.) in
   ignore (Miou.await a);
   ignore (Miou.await b)
 
@@ -215,7 +215,7 @@ not fancy, but it has the merit of having worked for quite some time.
 
 As you can imagine, this little introduction is not complete if we take into
 account {!val:Miou.call}. Miou can launch tasks in parallel and these tasks
-can perform I/O. In our example, we can replace {!val:Miou.call_cc} with
+can perform I/O. In our example, we can replace {!val:Miou.async} with
 {!val:Miou.call}. The problems that will arise from such a change will be, to
 say the least, difficult to explain in full. However, they focus on a point that
 is fairly simple to see: we are {b not} protecting our [sleepers] from changes
@@ -229,7 +229,7 @@ done some parallel programming, these mechanisms can:
 
 Based on these findings, we propose a fairly simple design: a {i syscall}
 is {b always} managed by the domain that launched it. It is {b local} to the
-domain. It is somewhat equivalent to {!val:Miou.call_cc}, suspension only
+domain. It is somewhat equivalent to {!val:Miou.async}, suspension only
 ({!val:Miou.suspend}) operates concurrently with other tasks and each domain
 manages its own syscalls.
 

--- a/tutorials/sleepers/t01.ml
+++ b/tutorials/sleepers/t01.ml
@@ -43,8 +43,8 @@ let () =
   let t0 = Unix.gettimeofday () in
   let () =
     Miou.run ~events @@ fun () ->
-    let a = Miou.call_cc (fun () -> sleep 1.) in
-    let b = Miou.call_cc (fun () -> sleep 2.) in
+    let a = Miou.async (fun () -> sleep 1.) in
+    let b = Miou.async (fun () -> sleep 2.) in
     Miou.await_all [ a; b ]
     |> List.iter @@ function Ok () -> () | Error exn -> raise exn
   in

--- a/tutorials/sleepers/t02.ml
+++ b/tutorials/sleepers/t02.ml
@@ -52,8 +52,8 @@ let () =
   let t0 = Unix.gettimeofday () in
   let () =
     Miou.run ~events @@ fun () ->
-    let a = Miou.call_cc (fun () -> sleep 1.) in
-    let b = Miou.call_cc (fun () -> sleep 2.) in
+    let a = Miou.async (fun () -> sleep 1.) in
+    let b = Miou.async (fun () -> sleep 2.) in
     Miou.await_all [ a; b ]
     |> List.iter @@ function Ok () -> () | Error exn -> raise exn
   in

--- a/tutorials/sleepers/t03.ml
+++ b/tutorials/sleepers/t03.ml
@@ -81,8 +81,8 @@ let () =
   let t0 = Unix.gettimeofday () in
   let () =
     Miou.run ~events @@ fun () ->
-    let a = Miou.call_cc (fun () -> sleep 1.) in
-    let b = Miou.call_cc (fun () -> sleep 2.) in
+    let a = Miou.async (fun () -> sleep 1.) in
+    let b = Miou.async (fun () -> sleep 2.) in
     Miou.await_all [ a; b ]
     |> List.iter (function Ok () -> () | Error exn -> raise exn)
   in


### PR DESCRIPTION
Miou is still in a state where we can afford to ‘break’ the API abruptly. The term `call_cc` seems not to be appreciated for good reasons (referring to notions that have nothing to do with what the function wants to offer) and the term `async` seems closer to what we want to offer.

From my point of view, it's a bit of shame that the latter can refer to `Lwt.async`, which is contrary to what we want to propose with Miou - but that's life...

In that respect, this PR is above all a proposal where we can share an opinion on the term we should use to launch concurrent tasks. This debate will take place in two stages:
- 1 week to collect other possible solutions
- 1 week to vote


Of course, if nobody speaks up, the choice will be made to use `Miou.async`.

/cc @Armael /cc @kit-ty-kate /cc @hannesm & @reynir 