### PR TITLE
Allow setting reuseaddr and reuseport

### DIFF
--- a/lib/miou_unix.ml
+++ b/lib/miou_unix.ml
@@ -18,9 +18,9 @@ let tcpv6 () =
   let fd = Unix.socket Unix.PF_INET6 Unix.SOCK_STREAM 0 in
   Unix.set_nonblock fd; { fd; non_blocking= true }
 
-let bind_and_listen ?(backlog = 64) { fd; _ } sockaddr =
-  Unix.setsockopt fd Unix.SO_REUSEADDR true;
-  Unix.setsockopt fd Unix.SO_REUSEPORT true;
+let bind_and_listen ?(backlog = 64) ?(reuseaddr = true) ?(reuseport = true) { fd; _ } sockaddr =
+  Unix.setsockopt fd Unix.SO_REUSEADDR reuseaddr;
+  Unix.setsockopt fd Unix.SO_REUSEPORT reuseport;
   Unix.bind fd sockaddr;
   Unix.listen fd backlog
 

--- a/lib/miou_unix.mli
+++ b/lib/miou_unix.mli
@@ -20,10 +20,13 @@ val tcpv4 : unit -> file_descr
 val tcpv6 : unit -> file_descr
 (** [tcpv6 ()] allocates a new IPv6 socket. *)
 
-val bind_and_listen : ?backlog:int -> file_descr -> Unix.sockaddr -> unit
+val bind_and_listen : ?backlog:int -> ?reuseaddr:bool -> ?reuseport:bool -> file_descr -> Unix.sockaddr -> unit
 (** [bind_and_listen fd sockaddr] binds the given socket to the given
     [sockaddr] and set up the given [fd] for receiving connection requests.
-    [backlog] is the maximal number of pending requests. *)
+    [backlog] is the maximal number of pending requests. The optional argument
+    [reuseaddr] (defaults to [true]) sets the [REUSEADDR] socket option on the
+    given [fd]. The optional argument [reuseport] (defaults to [true] sets the
+    [REUSEPORT] socket option on the given [fd]. *)
 
 val accept : ?cloexec:bool -> file_descr -> file_descr * Unix.sockaddr
 (** [accept ?cloexec fd] is a Miou friendly {!Unix.accept} which returns


### PR DESCRIPTION
Tiny patch to allow the user to pass their own reuseaddr and reuseport values to bind_and_listen. Does not change default behaviour.