### PR TITLE
Set the output pipe as a non-block fd and catch EAGAIN when we write into it

### DIFF
--- a/lib/miou_unix.ml
+++ b/lib/miou_unix.ml
@@ -331,12 +331,11 @@ let transmit_fds signals revert tbl fds =
 
 let interrupted fd fds = List.exists (( = ) fd) fds
 
-let intr fd interrupted =
+let intr fd =
   let buf = Bytes.create 0x100 in
   ignore (Unix.read fd buf 0 (Bytes.length buf));
-  ignore (Atomic.fetch_and_add interrupted (-1))
 
-let select uid (interrupt, p) ~block cancelled_syscalls =
+let select uid interrupt ~block cancelled_syscalls =
   let domain = domain () in
   clean domain cancelled_syscalls;
   let rds = file_descrs domain.readers in
@@ -367,25 +366,25 @@ let select uid (interrupt, p) ~block cancelled_syscalls =
       if interrupted interrupt rds then begin
         Logs.debug (fun m ->
             m "[%a] interrupted by Miou" Miou.Domain.Uid.pp uid);
-        intr interrupt p
+        intr interrupt
       end;
       let signals = collect domain [] in
       let signals = transmit_fds signals domain.revert domain.readers rds in
       let signals = transmit_fds signals domain.revert domain.writers wrs in
       signals
 
-let rec interrupt oc interrupted () =
-  if Atomic.get interrupted = 0 then
-    if Unix.single_write oc signal 0 1 = 0 then interrupt oc interrupted ()
-    else ignore (Atomic.fetch_and_add interrupted 1)
+let interrupt oc () =
+  match Unix.single_write oc signal 0 1 with
+  | _ -> ()
+  | exception Unix.(Unix_error (EAGAIN, _, _)) -> ()
 
 and signal = Bytes.make 1 '\000'
 
 let events domain =
   let ic, oc = Unix.pipe ~cloexec:true () in
-  let interrupted = Atomic.make 0 in
-  let select = select domain (ic, interrupted) in
-  let t = { Miou.interrupt= interrupt oc interrupted; select } in
+  Unix.set_nonblock oc;
+  let select = select domain ic in
+  let t = { Miou.interrupt= interrupt oc; select } in
   let close _ = Unix.close ic; Unix.close oc in
   Gc.finalise close t; t
 

--- a/lib/miou_unix.ml
+++ b/lib/miou_unix.ml
@@ -374,12 +374,12 @@ let select uid interrupt ~block cancelled_syscalls =
       let signals = transmit_fds signals domain.revert domain.writers wrs in
       signals
 
+let signal = Bytes.make 1 '\000'
 let interrupt oc () =
   match Unix.single_write oc signal 0 1 with
   | n -> assert (n = 1) (* XXX(dinosaure): paranoid mode. *)
   | exception Unix.(Unix_error (EAGAIN, _, _)) -> ()
 
-and signal = Bytes.make 1 '\000'
 
 let events domain =
   let ic, oc = Unix.pipe ~cloexec:true () in


### PR DESCRIPTION
/cc @haesbaert this is my first try to fix the pipe used to interrupt a domain. WDYT?