### PR TITLE
Be able to finalise correctly ressources allocated by the events function when the domain stop

### DIFF
--- a/lib/miou.mli
+++ b/lib/miou.mli
@@ -1104,7 +1104,12 @@ val uid : syscall -> uid
 (** [uid syscall] returns the unique ID of the syscall. *)
 
 type select = block:bool -> uid list -> signal list
-type events = { select: select; interrupt: unit -> unit }
+
+type events = {
+    select: select
+  ; interrupt: unit -> unit
+  ; finaliser: unit -> unit
+}
 
 val run :
      ?quanta:int

--- a/lib/miou_queue.ml
+++ b/lib/miou_queue.ml
@@ -118,8 +118,7 @@ let iter ~f (head, tail) =
 
 let rec drop t =
   let ((head, tail) as snapshot) = snapshot t in
-  if Atomic.compare_and_set t.head head tail
-  then snapshot else drop t
+  if Atomic.compare_and_set t.head head tail then snapshot else drop t
 
 let drop ~f t = iter ~f (drop t)
 let iter ~f t = iter ~f (snapshot t)

--- a/lib/miou_unix.ml
+++ b/lib/miou_unix.ml
@@ -388,8 +388,7 @@ let events domain =
   Unix.set_nonblock ic;
   Unix.set_nonblock oc;
   let select = select domain ic in
-  let t = { Miou.interrupt= interrupt oc; select } in
-  let close _ = Unix.close ic; Unix.close oc in
-  Gc.finalise close t; t
+  let finaliser () = Unix.close ic; Unix.close oc in
+  { Miou.interrupt= interrupt oc; select; finaliser }
 
 let run ?g ?domains fn = Miou.run ~events ?g ?domains fn

--- a/test/test_core.ml
+++ b/test/test_core.ml
@@ -389,7 +389,7 @@ module Miouc = struct
     let value = Atomic.make false in
     let select = select uid value in
     let interrupt () = Atomic.set value true in
-    { Miou.interrupt; select }
+    { Miou.interrupt; select; finaliser= Fun.const () }
 
   let run ?g ?domains fn = Miou.run ~events ?g ?domains fn
 
@@ -511,7 +511,7 @@ let test28 =
   let select ~block:_ _ =
     match !global with Some value -> [ Miou.signal value ] | None -> []
   in
-  let events _ = { Miou.interrupt= ignore; select } in
+  let events _ = { Miou.interrupt= ignore; select; finaliser= Fun.const () } in
   let prgm () =
     Miou.run ~events @@ fun () ->
     let p = Miou.syscall () in

--- a/tutorials/sleepers/sleepers.mld
+++ b/tutorials/sleepers/sleepers.mld
@@ -91,7 +91,7 @@ can run this code:
 {[
 let dummy _ =
   let select ~block:_ _cancelled_syscalls = [] in
-  { Miou.select; Miou.interrupt= ignore }
+  { Miou.select; Miou.interrupt= ignore; Miou.finaliser= ignore }
 
 let () = Miou.(run ~events:dummy @@ fun () -> sleep 1.; ())
 ]}
@@ -387,11 +387,19 @@ let select interrupt ~block cancelled =
 
 let events _ =
   let ic, oc = Unix.pipe ~cloexec:true () in
+  let finaliser () = Unix.close ic; Unix.close oc in
   let rec interrupt () =
     if Unix.write oc (Bytes.make 1 '\000') 0 1 = 0 then interrupt ()
   in
-  { Miou.select= select ic; interrupt }
+  { Miou.select= select ic; interrupt; finaliser }
 ]}
+
+The allocation of two file descriptors using a [Unix.pipe] must also be
+associated with a “finaliser” closing these two file descriptors. In addition to
+[interrupt], Miou requires a [finaliser] function that will be called as soon as
+the domain that allocated the two file-descriptors shuts down. This allows the
+user to release the resources he has allocated to build the events value per
+domain.
 
 {4 The [block] argument.}
 

--- a/tutorials/sleepers/t01.ml
+++ b/tutorials/sleepers/t01.ml
@@ -37,7 +37,7 @@ let select ~block:_ _ =
         sleepers;
       !cs
 
-let events _ = { select; interrupt= ignore }
+let events _ = { select; interrupt= ignore; finaliser= ignore }
 
 let () =
   let t0 = Unix.gettimeofday () in

--- a/tutorials/sleepers/t02.ml
+++ b/tutorials/sleepers/t02.ml
@@ -46,7 +46,7 @@ let select ~block:_ _ =
       set sleepers;
       !cs
 
-let events _ = { select; interrupt= ignore }
+let events _ = { select; interrupt= ignore; finaliser= ignore }
 
 let () =
   let t0 = Unix.gettimeofday () in

--- a/tutorials/sleepers/t03.ml
+++ b/tutorials/sleepers/t03.ml
@@ -75,7 +75,8 @@ let events _ =
   let rec interrupt () =
     if Unix.write oc (Bytes.make 1 '\000') 0 1 = 0 then interrupt ()
   in
-  { Miou.select= select ic; interrupt }
+  let finaliser () = Unix.close ic; Unix.close oc in
+  { Miou.select= select ic; interrupt; finaliser }
 
 let () =
   let t0 = Unix.gettimeofday () in


### PR DESCRIPTION
It's a file-descriptor leak spotted when we do a lot of `Miou_unix.run` (which is not the usual usage). However, it seems that the `Gc.finalise` does not work properly (or it never triggered). It seems that we must use the `clean at the shutdown` option (eg. `OCAMLRUNPARAM=c`) to be sure that everything (including finalisers) is cleaned but we should not impose to the user to use every-time this option.