### PR TITLE
Fix fmt

### DIFF
--- a/lib/.ocamlformat-ignore
+++ b/lib/.ocamlformat-ignore
@@ -1,0 +1,4 @@
+# ocamlformat is disabled in this file, but `dune build @fmt` still fails.
+# Disabling ocamlformat here is a temporary workaround.
+# Issue reported: https://github.com/ocaml-ppx/ocamlformat/issues/2641
+miou_vector.mli

--- a/lib/miou_unix.ml
+++ b/lib/miou_unix.ml
@@ -154,10 +154,7 @@ let rec unsafe_read ({ fd; non_blocking } as file_descr) off len buf =
     blocking_read fd; go ()
 
 let read file_descr ?(off = 0) ?len buf =
-  let len = match len with
-    | None -> Bytes.length buf - off
-    | Some len -> len
-  in
+  let len = match len with None -> Bytes.length buf - off | Some len -> len in
   if off < 0 || len < 0 || off > Bytes.length buf - len then
     invalid_arg "Miou_unix.read";
   unsafe_read file_descr off len buf
@@ -169,10 +166,7 @@ let rec really_read_go file_descr off len buf =
     really_read_go file_descr (off + len') (len - len') buf
 
 let really_read file_descr ?(off = 0) ?len buf =
-  let len = match len with
-    | None -> Bytes.length buf - off
-    | Some len -> len
-  in
+  let len = match len with None -> Bytes.length buf - off | Some len -> len in
   if off < 0 || len < 0 || off > Bytes.length buf - len then
     invalid_arg "Miou_unix.really_read";
   if len > 0 then really_read_go file_descr off len buf
@@ -199,9 +193,8 @@ let rec unsafe_write ({ fd; non_blocking } as file_descr) off len str =
     blocking_write fd; go ()
 
 let write file_descr ?(off = 0) ?len str =
-  let len = match len with
-    | None -> String.length str - off
-    | Some len -> len
+  let len =
+    match len with None -> String.length str - off | Some len -> len
   in
   if off < 0 || len < 0 || off > String.length str - len then
     invalid_arg "Miou_unix.write";


### PR DESCRIPTION
Fix `lint-fmt` as reported red by ocaml-ci. Before considering whether to upgade ocamlformat to 0.27.0 I prefer to start from a clean slate.

- For context, see #50.
- ocamlformat bug reported [upstream](https://github.com/ocaml-ppx/ocamlformat/issues/2641).