### PR TITLE
Upgrade ocamlformat to 0.27.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+_opam
 _build
 _tests
 _b0

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.26.2
+version=0.27.0
 exp-grouping=preserve
 break-infix=wrap-or-vertical
 break-collection-expressions=wrap

--- a/lib/miou.ml
+++ b/lib/miou.ml
@@ -1074,8 +1074,8 @@ type 'a orphans = {
   ; length: int Atomic.t
 }
 
-let rec add_into_orphans :
-    type a. ?backoff:Backoff.t -> self:'x t -> a t -> a orphans -> unit =
+let rec add_into_orphans : type a.
+    ?backoff:Backoff.t -> self:'x t -> a t -> a orphans -> unit =
  fun ?(backoff = Backoff.default) ~self prm ({ orphans; owner; length } as v) ->
   match Atomic.get owner with
   | None ->
@@ -1370,8 +1370,8 @@ let orphans () =
 
 let length orphans = Atomic.get orphans.length
 
-let domain_safe_care :
-    type a. a t Miou_sequence.t -> int Atomic.t -> a t option option =
+let domain_safe_care : type a.
+    a t Miou_sequence.t -> int Atomic.t -> a t option option =
  fun orphans length ->
   if Miou_sequence.is_empty orphans then None
   else
@@ -1387,8 +1387,8 @@ let domain_safe_care :
       let prm = Miou_sequence.data node in
       Miou_sequence.remove node; Atomic.decr length; Some (Some prm)
 
-let rec care :
-    type a. ?backoff:Backoff.t -> self:'x t -> a orphans -> a t option option =
+let rec care : type a.
+    ?backoff:Backoff.t -> self:'x t -> a orphans -> a t option option =
  fun ?(backoff = Backoff.default) ~self ({ orphans; owner; length } as v) ->
   match Atomic.get owner with
   | None ->

--- a/lib/miou.mli
+++ b/lib/miou.mli
@@ -24,18 +24,14 @@
       let handler =
         let retc = Fun.id in
         let exnc = raise in
-        let effc
-          : type c. c Effect.t -> ((c, 'a) continuation -> 'a) option
-          = function
-          | Hello ->
-            Some (fun k -> continue k (print_endline "Hello"))
-          | _ -> None in
+        let effc : type c. c Effect.t -> ((c, 'a) continuation -> 'a) option =
+          function
+          | Hello -> Some (fun k -> continue k (print_endline "Hello"))
+          | _ -> None
+        in
         { retc; exnc; effc }
 
-      let my_function () =
-        Effect.perform Hello;
-        print_endline "World"
-
+      let my_function () = Effect.perform Hello; print_endline "World"
       let () = match_with my_function () handler
     ]}
 
@@ -49,20 +45,13 @@
     {[
       exception Hello
 
-      let my_function () =
-        raise Hello;
-        print_endline "World"
-
-      let () =
-        try my_function ()
-        with Hello k ->
-          print_endline "Hello";
-          k ()
+      let my_function () = raise Hello; print_endline "World"
+      let () = try my_function () with Hello k -> print_endline "Hello"; k ()
     ]}
 
     Miou defines several effects that allow the user to interact with Miou's
-    "task manager". Miou's effects manager is installed using {!val:run}. So,
-    if you want to use Miou, you should always start with {!val:run}:
+    "task manager". Miou's effects manager is installed using {!val:run}. So, if
+    you want to use Miou, you should always start with {!val:run}:
 
     {[
       val my_program : unit -> unit
@@ -73,8 +62,8 @@
     {3 A task manager.}
 
     Miou is a task manager. In other words, it manages a list of to-do tasks
-    (which you can add to with {!val:async}/{!val:call}) and allows the user
-    to manage these tasks. When a task is created, Miou gives the user a
+    (which you can add to with {!val:async}/{!val:call}) and allows the user to
+    manage these tasks. When a task is created, Miou gives the user a
     representation of the task: a promise {!type:t}.
 
     From this promise, the user can:
@@ -84,12 +73,11 @@
     Here's an example where a list of tasks are initiated and awaited.
     Interaction (task creation and awaiting) with Miou takes place via effects.
     Miou manages the execution order of these tasks and attempts to finish them
-    all in order to terminate your program. 
+    all in order to terminate your program.
 
     {[
       let digest filename =
-        Miou.async @@ fun () ->
-        (filename, Digest.file filename)
+        Miou.async @@ fun () -> (filename, Digest.file filename)
 
       let my_program filenames =
         (* 1) we create a list of tasks *)
@@ -98,12 +86,12 @@
         (* 3) we wait these tasks *)
         let results = List.map Miou.await_exn prms in
         (* 4) we print results *)
-        List.iter (fun (filename, hash) ->
-          Format.printf "%s: %s\n%!" filename (Digest.to_hex hash))
+        List.iter
+          (fun (filename, hash) ->
+            Format.printf "%s: %s\n%!" filename (Digest.to_hex hash))
           results
 
-      let () = Miou.run @@ fun () ->
-        my_program ["file01.ml"; "file02.ml"]
+      let () = Miou.run @@ fun () -> my_program [ "file01.ml"; "file02.ml" ]
     ]}
 
     Miou suggests a {{!page:scheduler}little exercise} to implement a task
@@ -151,14 +139,14 @@
     {3 Preemption and cooperation}
 
     OCaml offers only a fundamentally cooperative model for executing these
-    tasks. Indeed, there are no mechanisms in OCaml to force the suspension of
-    a given task. However, a given task can suspend itself in order to cooperate
+    tasks. Indeed, there are no mechanisms in OCaml to force the suspension of a
+    given task. However, a given task can suspend itself in order to cooperate
     with other tasks on a limited resource such as a particular domain.
 
     Miou offers a way of creating tasks (see {!val:async}) that are more
     precisely called {i fibers}. These fibers must cooperate with each other to
     share the domain on which they run. This means that a fiber should not have
-    exclusive domain control when other fibers are waiting to be executed. 
+    exclusive domain control when other fibers are waiting to be executed.
 
     {[
       # Miou.run @@ fun () ->
@@ -185,8 +173,8 @@
     The problem with cooperation is that it does not take into account the
     irruption of external elements such as system events. Miou's objective is to
     be able to {i interrupt} your application as soon as these events occur: in
-    other words, to {b preempt} the interruption of your tasks when these
-    events occur.
+    other words, to {b preempt} the interruption of your tasks when these events
+    occur.
 
     {4 Availability.}
 
@@ -201,14 +189,16 @@
     that your application can handle this event as a priority.
 
     {[
-      let _, _ = Miou.run @@ fun () ->
+      let _, _ =
+        Miou.run @@ fun () ->
         let rec server () =
           let socket = accept () in
           let _ = Miou.call (handler socket) in
-          server () in
+          server ()
+        in
         let prm0 = Miou.async server in
         let prm1 = Miou.async my_long_computation in
-        Miou.both prm0 prm1 ;;
+        Miou.both prm0 prm1
 
       (* [my_long_computation] should have multiple cooperative points to let
          the other task (our [server]) to accept incoming TCP/IP connexions. *)
@@ -219,7 +209,7 @@
     services (such as an HTTP server) where the availability to handle such
     events is more important than prioritizing the calculation requested by a
     client.
- 
+
     {4 Cooperation and effects.}
 
     And therein lies the crux of the problem: how do you preempt in a
@@ -299,16 +289,18 @@
         let fds = Hashtbl.to_seq_keys global |> List.of_seq in
         match Unix.select fds [] [] 0.1 with
         | fds, _, _ ->
-          let signals = List.map (fun fd ->
-              let syscall = Hashtbl.find global fd in
-              let signal = Miou.signal syscall in
-              Hashtbl.remove global fd; signal)
-            fds in
-          signals
+            let signals =
+              List.map
+                (fun fd ->
+                  let syscall = Hashtbl.find global fd in
+                  let signal = Miou.signal syscall in
+                  Hashtbl.remove global fd; signal)
+                fds
+            in
+            signals
 
       let run fn =
-        let events _domain =
-          { Miou.select; interrupt= Fun.const () } in
+        let events _domain = { Miou.select; interrupt= Fun.const () } in
         Miou.run ~events fn
     ]}
 
@@ -319,8 +311,8 @@
     + or the ability to wait only for system events
     + or the ability to interrupt such an observation
 
-    We recommend reading the chapter on {{!section:system}system events}
-    and its tutorial on {!page:sleepers}.
+    We recommend reading the chapter on {{!section:system}system events} and its
+    tutorial on {!page:sleepers}.
 
     {3 User task management.}
 
@@ -330,21 +322,21 @@
     its use.
 
     {4 Rule 1, await for all your tasks.}
-    
+
     It is forbidden to forget your children. The creation of a task necessarily
     implies that the developer {!val:await}s or {!val:cancel}s the task
     afterwards:
-    
+
     {[
       # Miou.run @@ fun () -> Miou.async (Fun.const ()) ;;
       Exception: Miou.Still_has_children.
     ]}
-    
+
     {4:rule-2 Rule 2, only await for direct children.}
-    
+
     You can only await for your direct children. Transferring a promise to
     another task so that it can await for it is illegal:
-    
+
     {[
       # Miou.run @@ fun () ->
         let p = Miou.async (Fun.const ()) in
@@ -357,16 +349,16 @@
     should transmit to each other. To answer this question, users will have to
     find their own mechanisms ({!module:Mutex}, {!module:Condition}, {i ipc},
     etc.) to share results between tasks that are not directly related.
-    
+
     {4 Rule 3, a task can only be awaited or cancelled.}
-    
+
     Miou only allows you to await for or cancel a task. It is also impossible to
     detach a task. For more information on this subject, we recommend reading
     the {!section:orphans} section and our following rule:
     {{!section:background}background tasks}.
-    
+
     {4 Rule 4, a task only finishes after its children have finished.}
-    
+
     By extension, as soon as a task is finished, all its children are finished
     too. The same applies to cancellation. If you cancel a task, you also cancel
     its children.
@@ -402,7 +394,8 @@
     However, you can involve [dom0] in the calculations with {!val:async}.
 
     {[
-      let () = Miou.run ~domains:3 @@ fun () ->
+      let () =
+        Miou.run ~domains:3 @@ fun () ->
         let prm = Miou.async server in
         Miou.parallel server (List.init 3 (Fun.const ()))
         |> List.iter (function Ok () -> () | Error exn -> raise exn);
@@ -436,7 +429,7 @@
         let dom = Stdlib.Domain.DLS.new_key make in
         let get () = Stdlib.Domain.DLS.get dom in
         let set value = Stdlib.Domain.DLS.set dom value in
-        get, set
+        (get, set)
 
       let miou_read fd buf off len =
         let syscall = Miou.syscall () in
@@ -445,8 +438,7 @@
         set tbl;
         Miou.suspend syscall;
         Unix.read fd buf off len
-    ]}
-*)
+    ]} *)
 
 module Pqueue = Miou_pqueue
 module Logs = Miou_logs
@@ -539,8 +531,7 @@ module Ownership : sig
       released).
 
       The aim of this module is to ensure that when a task is completed, all
-      resources have been released.
-  *)
+      resources have been released. *)
 
   type t
   (** The type of resources. *)
@@ -609,8 +600,10 @@ module Ownership : sig
 
         let with_timeout ~give sec fn =
           Miou.await_first
-            [ Miou.async @@ fun () -> Miou_unix.sleep sec; raise Timeout
-            ; Miou.async ~give fn ] ;;
+            [
+              ( Miou.async @@ fun () ->
+                Miou_unix.sleep sec; raise Timeout; Miou.async ~give fn )
+            ]
 
         let connect socket sockaddr =
           let t = Miou_unix.Ownership.resource socket in
@@ -674,8 +667,8 @@ type 'a orphans
 (** The type of orphan collectors. *)
 
 val orphans : unit -> 'a orphans
-(** [orphans ()] makes a new orphan collectors which can used by {!val:call}
-    and {!val:async}. *)
+(** [orphans ()] makes a new orphan collectors which can used by {!val:call} and
+    {!val:async}. *)
 
 val care : 'a orphans -> 'a t option option
 (** [care orphans] returns a {i ready-to-await} promise or [Some None]. The user
@@ -684,12 +677,12 @@ val care : 'a orphans -> 'a t option option
     returns [None], no children left behind, you can forget the {!type:orphans}
     value safely.
 
-    @raise Invalid_argument [orphans] are necessarily attached to a promise,
-    keeping the children of that promise in an orphanage. So, if [care] is used
-    elsewhere than in the promise, an exception is raised to warn the user of a
-    misuse of [care]. Indeed, the child returned by care can only be awaited
-    ({!await}) by its direct parent (in reference to
-    {{!section:rule-2}our second rule}). *)
+    @raise Invalid_argument
+      [orphans] are necessarily attached to a promise, keeping the children of
+      that promise in an orphanage. So, if [care] is used elsewhere than in the
+      promise, an exception is raised to warn the user of a misuse of [care].
+      Indeed, the child returned by care can only be awaited ({!await}) by its
+      direct parent (in reference to {{!section:rule-2}our second rule}). *)
 
 val length : _ orphans -> int
 (** [length orphans] returns the number of remaining tasks. *)
@@ -698,15 +691,14 @@ val length : _ orphans -> int
 
 val async :
   ?give:Ownership.t list -> ?orphans:'a orphans -> (unit -> 'a) -> 'a t
-(** [async fn] (for Call with Current Continuation) returns a promise
-    {!type:t} representing the state of the task given as an argument. The task
-    will be executed {b concurrently} with the other tasks in the current
-    domain.
+(** [async fn] (for Call with Current Continuation) returns a promise {!type:t}
+    representing the state of the task given as an argument. The task will be
+    executed {b concurrently} with the other tasks in the current domain.
 
-    @raise Invalid_argument a promise can only be attached to an orphan if the
-    latter is owned by the parent promise. For the example, this code doesn't
-    work because we're trying to attach 2 promises that don't have the same
-    direct parent:
+    @raise Invalid_argument
+      a promise can only be attached to an orphan if the latter is owned by the
+      parent promise. For the example, this code doesn't work because we're
+      trying to attach 2 promises that don't have the same direct parent:
 
     {[
       # Miou.run @@ fun () ->
@@ -732,25 +724,29 @@ val call :
     is always true:
 
     {[
-      let () = Miou.run @@ fun () ->
-        let p = Miou.call @@ fun () ->
+      let () =
+        Miou.run @@ fun () ->
+        let p =
+          Miou.call @@ fun () ->
           let u = Miou.Domain.self () in
           let q = Miou.call @@ fun () -> Miou.Domain.self () in
-          (u, Miou.await_exn q) in
+          (u, Miou.await_exn q)
+        in
         let u, v = Miou.await_exn p in
-        assert (v <> u) ;;
+        assert (v <> u)
     ]}
 
     Sequential calls to {!val:call} do not guarantee that different domains are
     always chosen. This code {b may} be true.
 
     {[
-      let () = Miou.run @@ fun () ->
+      let () =
+        Miou.run @@ fun () ->
         let p = Miou.call @@ fun () -> Miou.Domain.self () in
         let q = Miou.call @@ fun () -> Miou.Domain.self () in
         let u = Miou.await_exn p in
         let v = Miou.await_exn q in
-        assert (u = v);
+        assert (u = v)
     ]}
 
     To ensure that tasks are properly allocated to all domains, you need to use
@@ -759,14 +755,14 @@ val call :
     {b NOTE}: {!val:call} will never run a task on {i dom0} (the main domain).
     Only the other domains can manage tasks in parallel.
 
-    @raise No_domain_available if no domain is available to execute the task in
-    parallel or if the function is executed by the only domain available in
-    parallel (it is impossible to assign a task to [dom0] from the other
-    domains).
+    @raise No_domain_available
+      if no domain is available to execute the task in parallel or if the
+      function is executed by the only domain available in parallel (it is
+      impossible to assign a task to [dom0] from the other domains).
 
-    @raise Invalid_argument like {!val:async}, if the promise should be
-    associated with an [orphan], the orphan should be owned by the direct
-    parent. *)
+    @raise Invalid_argument
+      like {!val:async}, if the promise should be associated with an [orphan],
+      the orphan should be owned by the direct parent. *)
 
 val parallel : ('a -> 'b) -> 'a list -> ('b, exn) result list
 (** [parallel fn lst] is the {i fork-join} model: it is a way of setting up and
@@ -793,8 +789,8 @@ val parallel : ('a -> 'b) -> 'a list -> ('b, exn) result list
       let sort ~compare (arr, lo, hi) =
         if hi - lo >= 2 then begin
           let mi = (lo + hi) / 2 in
-          ignore (Miou.parallel (sort ~compare)
-            [ (arr, lo, mi); (arr, mi, hi) ]);
+          ignore
+            (Miou.parallel (sort ~compare) [ (arr, lo, mi); (arr, mi, hi) ]);
           merge ~compare arr lo mi hi
         end
     ]}
@@ -812,7 +808,8 @@ val parallel : ('a -> 'b) -> 'a list -> ('b, exn) result list
     {[
       val server : unit -> unit
 
-      let () = Miou.run ~domains:3 @@ fun () ->
+      let () =
+        Miou.run ~domains:3 @@ fun () ->
         let p = Miou.async server in
         Miou.parallel server (List.init 3 (Fun.const ()))
         |> List.iter (function Ok () -> () | Error exn -> raise exn);
@@ -879,7 +876,7 @@ val await_one : 'a t list -> ('a, exn) result
       - : int = 1
     ]}
 
-    If several tasks finish "at the same time" (as is the case in our example 
+    If several tasks finish "at the same time" (as is the case in our example
     above), we prioritise the tasks that finished well and choose one at random.
 
     @raise Invalid_argument if the promise list is empty. *)
@@ -887,8 +884,8 @@ val await_one : 'a t list -> ('a, exn) result
 val await_first : 'a t list -> ('a, exn) result
 (** [await_first prms] awaits for a task to finish (by exception or normally)
     and cancels all the others. If several tasks finish "at the same time",
-    normally completed tasks are preferred to failed ones. This function can
-    be useful for timeouts:
+    normally completed tasks are preferred to failed ones. This function can be
+    useful for timeouts:
 
     {[
       # exception Timeout ;;
@@ -913,9 +910,9 @@ exception Cancelled
 (** Used when a task is cancelled by {!val:cancel}. *)
 
 val cancel : 'a t -> unit
-(** [cancel prm] {i asynchronously} cancels the given promise [prm]. Miou
-    allows the forgetting of a cancelled promise and the forgetting of its
-    children. For instance, this code is valid (despite the second one):
+(** [cancel prm] {i asynchronously} cancels the given promise [prm]. Miou allows
+    the forgetting of a cancelled promise and the forgetting of its children.
+    For instance, this code is valid (despite the second one):
 
     {[
       # Miou.run @@ fun () ->
@@ -1097,9 +1094,9 @@ val syscall : unit -> syscall
     suspension point via {!val:suspend}. *)
 
 val suspend : syscall -> unit
-(** [suspend syscall] creates an user's defined suspension point. Miou will
-    keep it internally and only the user is able to {i resume} it via
-    {!type:events} (and the [select] field) and a {!type:signal}. *)
+(** [suspend syscall] creates an user's defined suspension point. Miou will keep
+    it internally and only the user is able to {i resume} it via {!type:events}
+    (and the [select] field) and a {!type:signal}. *)
 
 val signal : syscall -> signal
 (** [signal syscall] creates a {!type:signal} value which can be used by Miou to
@@ -1175,12 +1172,13 @@ module Mutex : sig
       will restart. The mutex must have been previously locked by the thread
       that calls {!val:unlock}.
 
-      @raise Sysy_error was not raised when unlocking an unlocked mutex or when
-      unlocking a mutex from a different task. *)
+      @raise Sysy_error
+        was not raised when unlocking an unlocked mutex or when unlocking a
+        mutex from a different task. *)
 
   val lock : t -> unit
-  (** Lock the given mutex. Only one task can have the mutex locked at a time.
-      A task that attempts to lock a mutex already locked by another thread will
+  (** Lock the given mutex. Only one task can have the mutex locked at a time. A
+      task that attempts to lock a mutex already locked by another thread will
       suspend until the other thread unlocks the mutex. *)
 
   val try_lock : t -> bool
@@ -1241,8 +1239,8 @@ module Lazy : sig
   (** Represents a deferred computation of suspension. *)
 
   val from_val : 'a -> 'a t
-  (** [from_val value] returns an already forced suspension whose result is
-      the given [value]. *)
+  (** [from_val value] returns an already forced suspension whose result is the
+      given [value]. *)
 
   val from_fun : (unit -> 'a) -> 'a t
   (** [from_fun fn] returns a suspension. *)
@@ -1253,6 +1251,7 @@ module Lazy : sig
       suspension and reproduces its result. In case the suspension has already
       been forced the computation is skipped and stored result is reproduced.
 
-      @raise Undefined in case the suspension is currently being forced by the
-      current prommise. *)
+      @raise Undefined
+        in case the suspension is currently being forced by the current
+        prommise. *)
 end

--- a/lib/miou.mli
+++ b/lib/miou.mli
@@ -601,8 +601,8 @@ module Ownership : sig
         let with_timeout ~give sec fn =
           Miou.await_first
             [
-              ( Miou.async @@ fun () ->
-                Miou_unix.sleep sec; raise Timeout; Miou.async ~give fn )
+              (Miou.async @@ fun () -> Miou_unix.sleep sec; raise Timeout)
+            ; Miou.async ~give fn
             ]
 
         let connect socket sockaddr =

--- a/lib/miou_backoff.mli
+++ b/lib/miou_backoff.mli
@@ -25,7 +25,7 @@ val max_wait_log : int
 (** Logarithm of the maximum allowed value for wait. *)
 
 val create : ?lower_wait_log:int -> ?upper_wait_log:int -> unit -> t
-(** [create] creates a backoff value.  [upper_wait_log], [lower_wait_log]
+(** [create] creates a backoff value. [upper_wait_log], [lower_wait_log]
     override the logarithmic upper and lower bound on the number of spins
     executed by {!once}. *)
 

--- a/lib/miou_sequence.mli
+++ b/lib/miou_sequence.mli
@@ -25,14 +25,14 @@ val create : unit -> 'a t
 (** [create ()] creates a new empty sequence. *)
 
 val take : direction -> 'a t -> 'a
-(** [take direction t] takes an element of [t] from the specified
-    [direction]. *)
+(** [take direction t] takes an element of [t] from the specified [direction].
+*)
 
 val peek_node : direction -> 'a t -> 'a node
 
 val add : direction -> 'a t -> 'a -> unit
-(** [add direction t] adds a new element into [t] to the specified
-    [direction]. *)
+(** [add direction t] adds a new element into [t] to the specified [direction].
+*)
 
 val drop : 'a t -> unit
 (** Removes all nodes from the given sequence. The nodes are not actually

--- a/lib/miou_state.ml
+++ b/lib/miou_state.ml
@@ -25,8 +25,8 @@ let effc eff k = Suspended (k, eff)
 
 let handler_continue =
   let open Effect.Shallow in
-  let effc :
-      type c. c Effect.t -> ((c, 'a) Effect.Shallow.continuation -> 'b) option =
+  let effc : type c.
+      c Effect.t -> ((c, 'a) Effect.Shallow.continuation -> 'b) option =
    fun eff -> Some (effc eff)
   in
   { retc; exnc; effc }
@@ -37,8 +37,8 @@ let continue_with : ('c, 'a) continuation -> 'c -> 'a t =
 let handler_discontinue exn_and_bt =
   let open Effect.Shallow in
   let const _ = Finished (Error exn_and_bt) in
-  let effc :
-      type c. c Effect.t -> ((c, 'a) Effect.Shallow.continuation -> 'b) option =
+  let effc : type c.
+      c Effect.t -> ((c, 'a) Effect.Shallow.continuation -> 'b) option =
    fun _ -> Some const
   and retc = const
   and exnc = const in
@@ -89,14 +89,14 @@ let once : type a. perform:perform -> a t -> a t =
   | Suspended (fn, e) as state ->
       let k : type c. (c, a) continuation -> c Operation.t -> a t =
        fun fn -> function
-        | Return v -> continue_with fn v
-        | Fail (exn, bt) -> discontinue_with ~backtrace:bt fn exn
-        | Interrupt -> state
-        | Continue e -> suspended_with fn e
-        | Perform eff ->
-            let v = Effect.perform eff in
-            unhandled_with fn v
-        | Yield -> continue_with fn ()
+         | Return v -> continue_with fn v
+         | Fail (exn, bt) -> discontinue_with ~backtrace:bt fn exn
+         | Interrupt -> state
+         | Continue e -> suspended_with fn e
+         | Perform eff ->
+             let v = Effect.perform eff in
+             unhandled_with fn v
+         | Yield -> continue_with fn ()
       in
       perform.perform (k fn) e
 
@@ -111,14 +111,14 @@ let run : type a. quanta:int -> perform:perform -> a t -> a t =
   let exception Yield of a t in
   let k : type c. (c, a) continuation -> c Operation.t -> a t =
    fun fn -> function
-    | Return v -> continue_with fn v
-    | Fail (exn, bt) -> discontinue_with ~backtrace:bt fn exn
-    | Continue e -> suspended_with fn e
-    | Perform e ->
-        let v = Effect.perform e in
-        unhandled_with fn v
-    | Interrupt -> raise_notrace Break
-    | Yield -> raise_notrace (Yield (continue_with fn ()))
+     | Return v -> continue_with fn v
+     | Fail (exn, bt) -> discontinue_with ~backtrace:bt fn exn
+     | Continue e -> suspended_with fn e
+     | Perform e ->
+         let v = Effect.perform e in
+         unhandled_with fn v
+     | Interrupt -> raise_notrace Break
+     | Yield -> raise_notrace (Yield (continue_with fn ()))
   in
   let quanta = ref quanta and state = ref state in
   try

--- a/lib/miou_state.mli
+++ b/lib/miou_state.mli
@@ -1,13 +1,13 @@
 type ('a, 'b) continuation
 (** The type of continuations. [('a, 'b) continuation] is the state of a
-    function [_ -> 'b]. ['a] is the type of the value to {i continue}
-    the continuation. The user can also {i discontinue} with an exception
-    the continuation. *)
+    function [_ -> 'b]. ['a] is the type of the value to {i continue} the
+    continuation. The user can also {i discontinue} with an exception the
+    continuation. *)
 
 type error = exn * Printexc.raw_backtrace
 (** The type of errors. A continuation can raise or be cancelled by an
-    exception. We keep the backtrace (where the exception comes from) with
-    the exception raised/used. *)
+    exception. We keep the backtrace (where the exception comes from) with the
+    exception raised/used. *)
 
 (** The type of function states.
 
@@ -72,8 +72,8 @@ val run : quanta:int -> perform:perform -> 'a t -> 'a t
     nothing), even though there may be a few {i quanta} left, the function
     returns the last state obtained.
 
-    The same applies to {!val:yield}, except that the continuation has
-    burnt itself out. In other words, {!val:yield} is equivalent to
+    The same applies to {!val:yield}, except that the continuation has burnt
+    itself out. In other words, {!val:yield} is equivalent to
     [send (); interrupt] but costs only one {i quanta}. *)
 
 (**/**)

--- a/lib/miou_sync.mli
+++ b/lib/miou_sync.mli
@@ -20,8 +20,8 @@ module Trigger : sig
   (** [create ()] allocates a new trigger in the initial state. *)
 
   val is_initial : t -> bool
-  (** [is_initial t] dtermines whether the trigger [t] is in the initial
-      state. *)
+  (** [is_initial t] dtermines whether the trigger [t] is in the initial state.
+  *)
 
   val is_signaled : t -> bool
   (** [is_signaled t] determines whether the trigger [t] is in the signaled
@@ -30,16 +30,17 @@ module Trigger : sig
   val await : t -> (exn * Printexc.raw_backtrace) option
   (** [await t] waits for the trigger to be {!signal}ed.
 
-      The return value is [None] in case the trigger was signaled before
-      [await] or we resumed the underlying continuation normally. Otherwise,
-      the return value is [Some (exn, bt)], which indicates that the underlying
+      The return value is [None] in case the trigger was signaled before [await]
+      or we resumed the underlying continuation normally. Otherwise, the return
+      value is [Some (exn, bt)], which indicates that the underlying
       continuation has been cancelled and the caller should raise the exception.
       In either case, the caller is responsible for cleaning up. Usually this
       means making sure that no references to the trigger remain to avoid space
       leak.
 
-      @raise Invalid_argument if the trigger was in the awaiting state, which
-      means that multiple concurrent calls of [await] are being made. *)
+      @raise Invalid_argument
+        if the trigger was in the awaiting state, which means that multiple
+        concurrent calls of [await] are being made. *)
 
   type _ Effect.t +=
     private
@@ -62,9 +63,10 @@ module Trigger : sig
       Otherwise, the return value is [false], which means that the trigger was
       already in the signaled state.
 
-      @raise Invalid_argument if the trigger was in the awaiting state, which
-      means that either the owner or creator of the trigger made concurrent
-      calls to {!val:await} or the handler called [on_signal] more than once. *)
+      @raise Invalid_argument
+        if the trigger was in the awaiting state, which means that either the
+        owner or creator of the trigger made concurrent calls to {!val:await} or
+        the handler called [on_signal] more than once. *)
 end
 
 module Computation : sig
@@ -106,8 +108,8 @@ module Computation : sig
       cancelled. *)
 
   val raise_if_errored : 'a t -> unit
-  (** [raise_if_errored] raises the exception the computation was cancelled
-      with if it was errored. *)
+  (** [raise_if_errored] raises the exception the computation was cancelled with
+      if it was errored. *)
 
   val peek : 'a t -> ('a, exn * Printexc.raw_backtrace) result option
   (** [peek c] returns the result of the computation [c] or [None] in case the

--- a/lib/miou_unix.mli
+++ b/lib/miou_unix.mli
@@ -1,7 +1,7 @@
 (** {1 The Unix layer of Miou.}
 
-    This module offers a re-implementation of the I/O according to Miou's
-    model. This module is essentially concerned with reading and writing
+    This module offers a re-implementation of the I/O according to Miou's model.
+    This module is essentially concerned with reading and writing
     [Unix.file_descr] from sockets, pipes, fifos, terminals (and
     pseudo-terminals) and probably devices. For all these types of [file_descr],
     reading/writing can block (waiting for bytes or waiting for the system's
@@ -47,16 +47,16 @@ val bind_and_listen :
   -> file_descr
   -> Unix.sockaddr
   -> unit
-(** [bind_and_listen fd sockaddr] binds the given socket to the given
-    [sockaddr] and set up the given [fd] for receiving connection requests.
-    [backlog] is the maximal number of pending requests. The optional argument
-    [reuseaddr] (defaults to [true]) sets the [REUSEADDR] socket option on the
-    given [fd]. The optional argument [reuseport] (defaults to [true] sets the
-    [REUSEPORT] socket option on the given [fd]. *)
+(** [bind_and_listen fd sockaddr] binds the given socket to the given [sockaddr]
+    and set up the given [fd] for receiving connection requests. [backlog] is
+    the maximal number of pending requests. The optional argument [reuseaddr]
+    (defaults to [true]) sets the [REUSEADDR] socket option on the given [fd].
+    The optional argument [reuseport] (defaults to [true] sets the [REUSEPORT]
+    socket option on the given [fd]. *)
 
 val accept : ?cloexec:bool -> file_descr -> file_descr * Unix.sockaddr
-(** [accept ?cloexec fd] is a Miou friendly {!Unix.accept} which returns
-    file descritptors in non-blocking mode. *)
+(** [accept ?cloexec fd] is a Miou friendly {!Unix.accept} which returns file
+    descritptors in non-blocking mode. *)
 
 val connect : file_descr -> Unix.sockaddr -> unit
 (** [connect fd sockaddr] is a Miou friendly {!val:Unix.connect}. The function
@@ -69,12 +69,13 @@ val read : file_descr -> ?off:int -> ?len:int -> bytes -> int
     [0]). It returns the actual number of characters read, between 0 and [len]
     (inclusive).
 
-    @raise Unix_error raised by the system call {!val:Unix.read}. The function
-    handles {!val:Unix.EINTR}, {!val:Unix.EAGAIN} and {!val:Unix.EWOULDBLOCK}
-    exceptions and redo the system call.
+    @raise Unix_error
+      raised by the system call {!val:Unix.read}. The function handles
+      {!val:Unix.EINTR}, {!val:Unix.EAGAIN} and {!val:Unix.EWOULDBLOCK}
+      exceptions and redo the system call.
 
-    @raise Invalid_argument if [off] and [len] do not designate a valid range of
-    [buf] *)
+    @raise Invalid_argument
+      if [off] and [len] do not designate a valid range of [buf] *)
 
 val really_read : file_descr -> ?off:int -> ?len:int -> bytes -> unit
 (** [really_read fd buf ~off ~len] reads [len] bytes (defaults to
@@ -82,27 +83,29 @@ val really_read : file_descr -> ?off:int -> ?len:int -> bytes -> unit
     in byte sequence [buf], starting at position [off] in [buf] (defaults to
     [0]). If [len = 0], [really_read] does nothing.
 
-    @raise Unix_error raised by the system call {!val:Unix.read}. The function
-    handles {!val:Unix.EINTR}, {!val:Unix.EAGAIN} and {!val:Unix.EWOULDBLOCK}
-    exceptions and redo the system call.
+    @raise Unix_error
+      raised by the system call {!val:Unix.read}. The function handles
+      {!val:Unix.EINTR}, {!val:Unix.EAGAIN} and {!val:Unix.EWOULDBLOCK}
+      exceptions and redo the system call.
 
-    @raise End_of_file if {!val:Unix.read} returns [0] before [len] characters
-    have been read.
+    @raise End_of_file
+      if {!val:Unix.read} returns [0] before [len] characters have been read.
 
-    @raise Invalid_argument if [off] and [len] do not designate a valid range of
-    [buf] *)
+    @raise Invalid_argument
+      if [off] and [len] do not designate a valid range of [buf] *)
 
 val write : file_descr -> ?off:int -> ?len:int -> string -> unit
 (** [write fd str ~off ~len] writes [len] bytes (defaults to
     [String.length str - off]) from byte sequence [buf], starting at offset
     [off] (defaults to [0]), to the given file-descriptor [fd].
 
-    @raise Unix_error raised by the system call {!val:Unix.read}. The function
-    handles {!val:Unix.EINTR}, {!val:Unix.EAGAIN} and {!val:Unix.EWOULDBLOCK}
-    exceptions and redo the system call.
+    @raise Unix_error
+      raised by the system call {!val:Unix.read}. The function handles
+      {!val:Unix.EINTR}, {!val:Unix.EAGAIN} and {!val:Unix.EWOULDBLOCK}
+      exceptions and redo the system call.
 
-    @raise Invalid_argument if [off] and [len] do not designate a valid range of
-    [buf] *)
+    @raise Invalid_argument
+      if [off] and [len] do not designate a valid range of [buf] *)
 
 val close : file_descr -> unit
 (** [close fd] closes properly the given [fd]. *)

--- a/miou.opam
+++ b/miou.opam
@@ -26,4 +26,5 @@ depends: [
   "dns"               {with-test}
   "dns-client"        {with-test}
   "mtime"             {with-test & >= "2.0.0"}
+  "ocamlformat"       {with-dev-setup & = "0.27.0"}
 ]


### PR DESCRIPTION
Upgrade ocamlformat to current latest version available `0.27.0`.

- For context, see also #50.

Notable changes with this version:
- Build on OCaml `5.3.0`
- Enable parsing of doc string by default

Regarding parsing doc-strings, if you don't like this it is possible to disable (use the option `parse-docstrings = false` to restore the previous behavior). Please let me know if you prefer a PR that would explore doing that instead.

Interestingly, formatting the code examples in the doc string revealed a little bug in one of the examples due to mismatch parsing priorities, for the expression in this list:

```ocaml
        let with_timeout ~give sec fn =
          Miou.await_first
            [ Miou.async @@ fun () -> Miou_unix.sleep sec; raise Timeout
            ; Miou.async ~give fn ] ;;
```

was actually parsed as:

```ocaml
              ( Miou.async @@ fun () ->
                Miou_unix.sleep sec; raise Timeout; Miou.async ~give fn )
```

I manually fixed this after applying the fmt by adding parenthesis.

All in, I don't feel strongly about whether the formatting is better or worse (looking at the PR I see instances of slight improvements, and instances of slightly worse formatting). I weakly feel in favor of enabling an automatic formatting to all code in the project, which would now include the code embedded in the doc. I'm imagining it is also nice to have machine assistance to make sure to respect the margin and other considerations while editing the doc comments in the project (although I personally don't have much experience with this option as of yet, so this is just an intuition at this time).