### PR TITLE
Semi-automatic cSpell pass to detect typos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,12 +7,12 @@
   (@ada2k, @dinosaure, #27)
 - Protect an illegal access to the orphan from a possibly parallel task which
   does not own the orphan value
-  (@poytypic, @dinosaure, #31, #32)
+  (@polytypic, @dinosaure, #31, #32)
 - Be able to pin a specific domain when we want to launch a parallel task
   (@dinosaure, #34)
 - Expose the `Miou.Backoff` module which can be useful for users
   (@dinosaure, #35)
-- Fix or improve (from the maintainance point-of-view) the `Miou.Queue` module
+- Fix or improve (from the maintenance point-of-view) the `Miou.Queue` module
   and some internal parts of Miou about the usage of atomics
   (@dinosaure, @polytypic, #36, #33)
 - Prefer to require a `finaliser` function for the `events` value and actually

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ let () = Miou.run @@ fun () ->
   let p0 = Miou.async @@ fun () -> 42 in
   let p1 = Miou.async @@ fun () -> Miou.await_exn p0 in
   Miou.await_exn p1
-Esxception: Miou.Not_a_child
+Exception: Miou.Not_a_child
 ```
 
 This rule dictates that passing values from one task to another requires
@@ -139,7 +139,7 @@ let prgm () =
 let rec until_its n =
   match prgm () with
   | Ok n' when n = n' -> ()
-  | _ -> untils_its n
+  | _ -> until_its n
 
 let () =
   until_its 1;
@@ -195,7 +195,7 @@ system resources through the API it can offer).
 I/O and the resources of a system. Mutexes, conditions or semaphores can also
 suspend the execution of a program. Our documentation and tutorials explain
 those cases that we consider *marginal* in the interest of internalizing
-suspension mecanism rather than exporting it to the user (but which are equally
+suspension mechanism rather than exporting it to the user (but which are equally
 important in the design of an application).
 
 ## Genesis

--- a/book/src/conditions_and_mutexes.md
+++ b/book/src/conditions_and_mutexes.md
@@ -47,7 +47,7 @@ let server () =
     let client, sockaddr = Miou_unix.Ownership.accept socket in
     Format.printf "new client: %a\n%!" pp_sockaddr sockaddr;
     ignore (Miou.async
-      ~give:[ Miou_unix.Ownership.resource clientr 
+      ~give:[ Miou_unix.Ownership.resource client ]
       ~orphans (fun () -> echo client))
   done;
   Miou_unix.Ownership.close socket
@@ -154,11 +154,11 @@ new connection.
 
 If we try this code, it may not work, and Miou might complain with the
 `Not_owner` exception. This is because our `accept` task does not own the
-file-descritptor; we need to pass it the resource via the `give` parameter.
+file-descriptor; we need to pass it the resource via the `give` parameter.
 
 It's worth noting that this ownership is exclusive. Once we've performed
 `Miou_unix.Ownership.accept`, we need to:
-1) transfer the file-descritptor back to the parent (so it can transfer it to
+1) transfer the file-descriptor back to the parent (so it can transfer it to
    the next `accept`).
 2) transfer the new file-descriptor to the parent that was created in our
    `accept` task so that it can transfer it to our `echo` task.

--- a/lib/miou.ml
+++ b/lib/miou.ml
@@ -606,7 +606,7 @@ module Domain = struct
           add_into_domain domain (Domain_task (prm, state))
     | false ->
         (* In that case, we must propagate the cancellation if [prm.state] has
-           ended abnormally. We try to attach tghe trigger to the compuatation
+           ended abnormally. We try to attach the trigger to the computation
            [prm.state]. Two situations are possible:
            - if we can attach the trigger, this means that the promise has not
              yet been cancelled/resolved. However, between attachment and

--- a/lib/miou.mli
+++ b/lib/miou.mli
@@ -201,7 +201,7 @@
         Miou.both prm0 prm1
 
       (* [my_long_computation] should have multiple cooperative points to let
-         the other task (our [server]) to accept incoming TCP/IP connexions. *)
+         the other task (our [server]) to accept incoming TCP/IP connections. *)
     ]}
 
     In other words, your application is "more" available to handle events than
@@ -962,7 +962,7 @@ val cancel : 'a t -> unit
 
 val yield : unit -> unit
 (** [yield ()] reschedules tasks and give an opportunity to carry out the tasks
-    that have been on hold the longest. For intance:
+    that have been on hold the longest. For instance:
 
     {[
       # Miou.run @@ fun () ->
@@ -1064,7 +1064,7 @@ end
 
     Finally, Miou informs the monitor of any points that have been cancelled, so
     that the associated events can no longer be monitored (this could involve
-    cleaning up the table of active file-descritpors).
+    cleaning up the table of active file-descriptors).
 
     {3 Tutorial.}
 
@@ -1128,7 +1128,7 @@ val sys_signal : int -> Sys.signal_behavior -> Sys.signal_behavior
     - [Signal_handle fn] calls [fn] (in the [dom0])
 
     [signal] is provided to be able to execute Miou's tasks when we receive a
-    signal from the system. The [dom0] takes the responsability to execute the
+    signal from the system. The [dom0] takes the responsibility to execute the
     given [fn]. *)
 
 val protect :
@@ -1252,6 +1252,6 @@ module Lazy : sig
       been forced the computation is skipped and stored result is reproduced.
 
       @raise Undefined
-        in case the suspension is currently being forced by the current
-        prommise. *)
+        in case the suspension is currently being forced by the current promise.
+  *)
 end

--- a/lib/miou_sync.mli
+++ b/lib/miou_sync.mli
@@ -20,7 +20,7 @@ module Trigger : sig
   (** [create ()] allocates a new trigger in the initial state. *)
 
   val is_initial : t -> bool
-  (** [is_initial t] dtermines whether the trigger [t] is in the initial state.
+  (** [is_initial t] determines whether the trigger [t] is in the initial state.
   *)
 
   val is_signaled : t -> bool

--- a/lib/miou_unix.mli
+++ b/lib/miou_unix.mli
@@ -56,7 +56,7 @@ val bind_and_listen :
 
 val accept : ?cloexec:bool -> file_descr -> file_descr * Unix.sockaddr
 (** [accept ?cloexec fd] is a Miou friendly {!Unix.accept} which returns file
-    descritptors in non-blocking mode. *)
+    descriptors in non-blocking mode. *)
 
 val connect : file_descr -> Unix.sockaddr -> unit
 (** [connect fd sockaddr] is a Miou friendly {!val:Unix.connect}. The function

--- a/lib/miou_vector.mli
+++ b/lib/miou_vector.mli
@@ -125,7 +125,7 @@ val get: 'a t -> int -> 'a
       ensures  x = a.view[i] *)
 
 val set: 'a t -> int -> 'a -> unit
-(** [set a n x] modifies aector [a] in place, replacing
+(** [set a n x] modifies vector [a] in place, replacing
     element number [n] with [x].
 
     Raise [Invalid_argument "Vector.set"]

--- a/lib/scheduler.mld
+++ b/lib/scheduler.mld
@@ -2,7 +2,7 @@
 
 This short tutorial shows you how to create a simple scheduler in OCaml with
 effects. We'd like to warn the reader that certain choices have been made to
-suit our purposes: in other words, as opposed to Tatcher, there {b are}
+suit our purposes: in other words, as opposed to Thatcher, there {b are}
 alternatives in implementing a scheduler. This tutorial is not {i absolutist} in
 what it explains.
 
@@ -193,7 +193,7 @@ We still need to define a few last elements for our scheduler so that the user
 can interact with it:
 - of course, there's the effect that will create a task
 - but also a promise as a {i witness} to the task's progress
-- from this promise, we can have a last interation, awaiting task completion
+- from this promise, we can have a last interaction, awaiting task completion
 
 Finally, a last type allows us to manipulate tasks independently of the type of
 their results.
@@ -276,8 +276,8 @@ consisting of 3 functions:
 + our effects installer
 
 {[
-let spawn fn = Effet.perform (Spawn fn)
-let await prm = Effet.perform (Await prm)
+let spawn fn = Effect.perform (Spawn fn)
+let await prm = Effect.perform (Await prm)
 
 let my_function =
   let prm = spawn @@ fun () -> print_endline "Hello" in


### PR DESCRIPTION
This is the results of a pass through with cSpell, where I looked briefly at the warnings generated. This is a semi-automatic pass, which would need to be completed by another read at a slower pace. By this I mean that I only went through the warnings that cSpell automatically generated (not the entire text), and then chose manually how to resolve them.

I used a combined en_US & en_GB dictionary, since both conventions seemed to be used in conjunction in the project (e.g. finalizer + finaliser, etc.).

For added context see #50 