### PR TITLE
Fix the way we record a new syscall outside Miou

### DIFF
--- a/lib/miou.mli
+++ b/lib/miou.mli
@@ -1093,10 +1093,20 @@ val syscall : unit -> syscall
 (** [syscall ()] creates a {i syscall} which permits the user to create a new
     suspension point via {!val:suspend}. *)
 
-val suspend : syscall -> unit
-(** [suspend syscall] creates an user's defined suspension point. Miou will keep
-    it internally and only the user is able to {i resume} it via {!type:events}
-    (and the [select] field) and a {!type:signal}. *)
+val suspend : ?fn:(unit -> unit) -> syscall -> unit
+(** [suspend ?fn syscall] creates an user's defined suspension point. Miou will
+    keep it internally and only the user is able to {i resume} it via
+    {!type:events} (and the [select] field) and a {!type:signal}.
+
+    The suspension makes several checks, making the operation {i non-atomic}. In
+    other words, [suspend] can be cancelled {b before} the suspension has been
+    effectively added internally.
+
+    To keep Miou and the system's event management synchronized, the [suspend]
+    function executes [fn] {b only} when the suspension has been effectively
+    added. Thus, for the user, the modification of the state managing system
+    events should take place in the [fn] function (and not before or after
+    [suspend]). *)
 
 val signal : syscall -> signal
 (** [signal syscall] creates a {!type:signal} value which can be used by Miou to

--- a/tutorials/sleepers/sleepers.mld
+++ b/tutorials/sleepers/sleepers.mld
@@ -74,8 +74,8 @@ let sleepers = Hashtbl.create 0x100
 
 let sleep until =
   let syscall = Miou.syscall () in
-  Hashtbl.add sleepers (Miou.uid syscall) (syscall, until);
-  Miou.suspend syscall
+  let fn () = Hashtbl.add sleepers (Miou.uid syscall) (syscall, until) in
+  Miou.suspend ~fn syscall
 ]}
 
 As you can see, the implementation of a 'syscall' is relatively simple, but it
@@ -255,9 +255,10 @@ let get, set =
 let sleep until =
   let syscall = Miou.make (Fun.const ()) in
   let sleepers = get () in
-  Hashtbl.add sleepers (Miou.uid syscall) (syscall, until);
-  set sleepers;
-  Miou.suspend syscall
+  let fn () =
+    Hashtbl.add sleepers (Miou.uid syscall) (syscall, until);
+    set sleepers in
+  Miou.suspend ~fn syscall
 ]}
 
 We then just need to call [get ()] & [set ()] in all the places where we use our

--- a/tutorials/sleepers/t01.ml
+++ b/tutorials/sleepers/t01.ml
@@ -4,8 +4,8 @@ let sleepers = Hashtbl.create 0x100
 
 let sleep until =
   let syscall = Miou.syscall () in
-  Hashtbl.add sleepers (Miou.uid syscall) (syscall, until);
-  Miou.suspend syscall
+  let fn () = Hashtbl.add sleepers (Miou.uid syscall) (syscall, until) in
+  Miou.suspend ~fn syscall
 
 let select ~block:_ _ =
   let min =

--- a/tutorials/sleepers/t02.ml
+++ b/tutorials/sleepers/t02.ml
@@ -10,9 +10,11 @@ let get, set =
 let sleep until =
   let syscall = Miou.syscall () in
   let sleepers = get () in
-  Hashtbl.add sleepers (Miou.uid syscall) (syscall, until);
-  set sleepers;
-  Miou.suspend syscall
+  let fn () =
+    Hashtbl.add sleepers (Miou.uid syscall) (syscall, until);
+    set sleepers
+  in
+  Miou.suspend ~fn syscall
 
 let select ~block:_ _ =
   let sleepers = get () in

--- a/tutorials/sleepers/t03.ml
+++ b/tutorials/sleepers/t03.ml
@@ -8,9 +8,11 @@ let get, set =
 let sleep until =
   let sleepers = get () in
   let syscall = Miou.syscall () in
-  Hashtbl.add sleepers (Miou.uid syscall) (syscall, until);
-  set sleepers;
-  Miou.suspend syscall
+  let fn () =
+    Hashtbl.add sleepers (Miou.uid syscall) (syscall, until);
+    set sleepers
+  in
+  Miou.suspend ~fn syscall
 
 let consume_interrupt ic =
   let buf = Bytes.create 0x1000 in


### PR DESCRIPTION


Currently, Miou.suspend performs several effects (2, at least). They are an opportunity to reschedule some tasks. It exists a case where a cancellation operates before we recorded the suspension of a new syscall in Miou. However, the upper layer (like Miou_unix) recorded the syscall as an active one (even if we cancelled the operation).

The implication of that is a Miou.suspend on a file-descriptor, a cancellation by a parent of this suspension but the registration of the file-descriptor as a valid one to monitor into Unix.select. Finally, Unix.select raises an exception because it manipulates a "Bad file descriptor" (the cancellation may be close the file-descriptor).

This PR update the book and the documentation.

It introduces a new argument to Miou.suspend: ?fn. This function is called when we know that **nothing** can interrupt Miou.suspend (even a cancellation from something). So it's better to append/record the file-descriptor in this function to be sure that we were not cancelled by something. By this way, we avoid this strange case where we decided to record a new file-descriptor even if we tried to cancel the task which wants to read/write.