### PR TITLE
Synchronize the dom0 when we receive a signal into another domain

### DIFF
--- a/lib/miou.ml
+++ b/lib/miou.ml
@@ -778,7 +778,7 @@ module Domain = struct
     transfer_dom0_tasks pool; transfer_dom0_signals pool
 
   let wakeup_dom0_if_needed pool =
-    if Queue.is_empty signals == false then
+    if not (Queue.is_empty signals) then
       let dom0 = Uid.of_int 0 in
       interrupt pool ~domain:dom0
 


### PR DESCRIPTION
This patch adds an interruption from other domains if we receive a signal into these domains. They signal dom0 (and unblock if dom0 is asleep) that it should consume the global [signals] queue.

/cc @omegametabroccolo, can you confirm that this draft fix your issue?