### PR TITLE
Add Miou.take

### DIFF
--- a/lib/miou.ml
+++ b/lib/miou.ml
@@ -1597,6 +1597,14 @@ let domain_safe_care : type a.
       let prm = Miou_sequence.data node in
       Miou_sequence.remove node; Atomic.decr length; Some (Some prm)
 
+let domain_safe_take : type a. a t Miou_sequence.t -> int Atomic.t -> a t option
+    =
+ fun orphans length ->
+  if Miou_sequence.is_empty orphans then None
+  else
+    let prm = Miou_sequence.(take Left) orphans in
+    Atomic.decr length; Some prm
+
 let rec care : type a.
     ?backoff:Backoff.t -> self:'x t -> a orphans -> a t option option =
  fun ?(backoff = Backoff.default) ~self ({ orphans; owner; length } as v) ->
@@ -1612,6 +1620,22 @@ let rec care : type a.
 let care orphans =
   let (Pack self) = Effect.perform Self in
   care ~self orphans
+
+let rec take : type a.
+    ?backoff:Backoff.t -> self:'x t -> a orphans -> a t option =
+ fun ?(backoff = Backoff.default) ~self ({ orphans; owner; length } as v) ->
+  match Atomic.get owner with
+  | None ->
+      if Atomic.compare_and_set owner None (Some self.uid) then
+        domain_safe_take orphans length
+      else take ~backoff:(Backoff.once backoff) ~self v
+  | Some uid ->
+      if Promise_uid.equal self.uid uid then domain_safe_take orphans length
+      else invalid_arg "The given orphans is owned by another promise"
+
+let take orphans =
+  let (Pack self) = Effect.perform Self in
+  take ~self orphans
 
 module Hook = struct
   type t = { uid: Domain.Uid.t; node: (unit -> unit) Miou_sequence.node }

--- a/lib/miou.mli
+++ b/lib/miou.mli
@@ -714,6 +714,17 @@ val care : 'a orphans -> 'a t option option
       Indeed, the child returned by care can only be awaited ({!await}) by its
       direct parent (in reference to {{!section:rule_2}our second rule}). *)
 
+val take : 'a orphans -> 'a t option
+(** [take orphans] returns a promise or [None]. The returned promise is in an
+    unknown state, meaning it is unclear whether it has completed or not.
+    However, it is no longer the responsibility of the given [orphans]. This
+    means that the user must (according to Miou's rules) consume it (using
+    {!val:Miou.await} or {!val:Miou.cancel}).
+
+    @raise Invalid_argument
+      As {!val:care}, [take] must be used in the promise that corresponds to the
+      parent of the promises held by the given [orphans].*)
+
 val length : _ orphans -> int
 (** [length orphans] returns the number of remaining tasks. *)
 

--- a/test/test_core.ml
+++ b/test/test_core.ml
@@ -829,7 +829,7 @@ module Bitv = Miou_unix.Bitv
 
 let test43 =
   let description = {text|Bitv.next|text} in
-  Test.test ~title:"test44" ~description @@ fun () ->
+  Test.test ~title:"test43" ~description @@ fun () ->
   let t = Bitv.create 1024 false in
   Test.check (Bitv.next t = Some 0);
   Bitv.set t (Option.get (Bitv.next t)) true;
@@ -844,7 +844,7 @@ let test43 =
 
 let test44 =
   let description = {text|Bitv.max|text} in
-  Test.test ~title:"test45" ~description @@ fun () ->
+  Test.test ~title:"test44" ~description @@ fun () ->
   let t = Bitv.create 1024 false in
   Test.check (Bitv.max t = 0);
   Bitv.set t (Option.get (Bitv.next t)) true;
@@ -855,6 +855,25 @@ let test44 =
   Bitv.set t 349 true;
   Test.check (Bitv.max t = 350)
 
+let test45 =
+  let description = {text|Miou.take|text} in
+  Test.test ~title:"test45" ~description @@ fun () ->
+  Miouc.reset ();
+  Miouc.run @@ fun () ->
+  let prm =
+    Miou.async @@ fun () ->
+    let orphans = Miou.orphans () in
+    let fn _ =
+      let sleep = Random.int 42 in
+      ignore (Miou.async ~orphans @@ fun () -> Miouc.sleep sleep)
+    in
+    let _ = List.init 42 fn in
+    let seq = Seq.of_dispenser (fun () -> Miou.take orphans) in
+    let lst = List.of_seq seq in
+    List.iter Miou.cancel lst
+  in
+  Miou.await_exn prm; Test.check true
+
 let () =
   let tests =
     [
@@ -862,7 +881,7 @@ let () =
     ; test10; test11; test12; test13; test14; test15; test16; test17; test18
     ; test19; test20; test21; test22; test23; test24; test25; test26; test27
     ; test28; test29; test30; test31; test32; test33; test34; test35; test36
-    ; test37; test38; test39; test40; test41; test42; test43; test44
+    ; test37; test38; test39; test40; test41; test42; test43; test44; test45
     ]
   in
   let ({ Test.directory } as runner) =


### PR DESCRIPTION
It can be useful to take all promises from an orphans and just cancel them (as we did on our tests). Miou.take comes from a old idea that we have during some experimentations: we always another solution than add this function into Miou but it's probably the time to provide it as required by httpcats to cancel useless tasks when an HTTP connection is finalized.

In our concrete example about httpcats, we have an orphans of tasks that read and write into a flow. It is possible to terminate an HTTP connection but a promise can still exists and probably suspended by a syscall read. In that situation, the best is to just cancel all of theses tasks because we ensured that the HTTP connection was done.