### PR TITLE
Add Miou.get and Miou.Promise.state

### DIFF
--- a/lib/miou.ml
+++ b/lib/miou.ml
@@ -1623,9 +1623,20 @@ let orphans () =
 
 let length orphans = Atomic.get orphans.length
 
-let domain_safe_care : type a.
-    a t Miou_sequence.t -> int Atomic.t -> a t option option =
- fun orphans length ->
+let rec acquire_orphans ?(backoff = Backoff.default) ~(self : _ t)
+    ({ owner; _ } as v) =
+  match Atomic.get owner with
+  | None ->
+      if not (Atomic.compare_and_set owner None (Some self.uid)) then
+        acquire_orphans ~backoff:(Backoff.once backoff) ~self v
+  | Some uid ->
+      if not (Promise_uid.equal self.uid uid) then
+        invalid_arg "The given orphans is owned by another promise"
+
+let care : type a. a orphans -> a t option option =
+ fun ({ orphans; length; _ } as v) ->
+  let (Pack self) = Effect.perform Self in
+  acquire_orphans ~self v;
   if Miou_sequence.is_empty orphans then None
   else
     let exception Orphan of a t Miou_sequence.node in
@@ -1640,45 +1651,83 @@ let domain_safe_care : type a.
       let prm = Miou_sequence.data node in
       Miou_sequence.remove node; Atomic.decr length; Some (Some prm)
 
-let domain_safe_take : type a. a t Miou_sequence.t -> int Atomic.t -> a t option
-    =
- fun orphans length ->
+let take ({ orphans; length; _ } as v) =
+  let (Pack self) = Effect.perform Self in
+  acquire_orphans ~self v;
   if Miou_sequence.is_empty orphans then None
   else
     let prm = Miou_sequence.(take Left) orphans in
     Atomic.decr length; Some prm
 
-let rec care : type a.
-    ?backoff:Backoff.t -> self:'x t -> a orphans -> a t option option =
- fun ?(backoff = Backoff.default) ~self ({ orphans; owner; length } as v) ->
-  match Atomic.get owner with
-  | None ->
-      if Atomic.compare_and_set owner None (Some self.uid) then
-        domain_safe_care orphans length
-      else care ~backoff:(Backoff.once backoff) ~self v
-  | Some uid ->
-      if Promise_uid.equal self.uid uid then domain_safe_care orphans length
-      else invalid_arg "The given orphans is owned by another promise"
-
-let care orphans =
+let get : type a. a orphans -> (a, exn) result option =
+ fun ({ orphans; length; _ } as v) ->
   let (Pack self) = Effect.perform Self in
-  care ~self orphans
-
-let rec take : type a.
-    ?backoff:Backoff.t -> self:'x t -> a orphans -> a t option =
- fun ?(backoff = Backoff.default) ~self ({ orphans; owner; length } as v) ->
-  match Atomic.get owner with
-  | None ->
-      if Atomic.compare_and_set owner None (Some self.uid) then
-        domain_safe_take orphans length
-      else take ~backoff:(Backoff.once backoff) ~self v
-  | Some uid ->
-      if Promise_uid.equal self.uid uid then domain_safe_take orphans length
-      else invalid_arg "The given orphans is owned by another promise"
-
-let take orphans =
-  let (Pack self) = Effect.perform Self in
-  take ~self orphans
+  acquire_orphans ~self v;
+  let g = Effect.perform Random in
+  if Miou_sequence.is_empty orphans then None
+  else begin
+    (* NOTE(dinosaure): as [await_one]. *)
+    let nodes = ref [] in
+    Miou_sequence.iter_node ~f:(fun node -> nodes := node :: !nodes) orphans;
+    let nodes = !nodes in
+    (* NOTE(dinosaure): snapshot of [nodes] which is safe. Only one promise can
+       manipulate our [orphans]. *)
+    let c = Computation.create () in
+    let choose =
+      Computation.try_capture c @@ fun () ->
+      let t = Trigger.create () in
+      let prm_of node = Miou_sequence.data node in
+      let take_one_and_detach_rest unattached attached =
+        List.iter
+          (fun node -> Computation.detach (prm_of node).state t)
+          attached;
+        let _, terminated =
+          List.partition
+            (fun node -> Promise.is_running (prm_of node))
+            (attached @ unattached)
+        in
+        let filter node =
+          if Result.is_ok (Option.get (Computation.peek (prm_of node).state))
+          then Either.Left node
+          else Either.Right node
+        in
+        let result, node =
+          match List.partition_map filter terminated with
+          | [], nodes | nodes, _ ->
+              let n = Random.State.int g (List.length nodes) in
+              let node = List.nth nodes n in
+              (Computation.await (prm_of node).state, node)
+        in
+        let prm = prm_of node in
+        Miou_sequence.remove node;
+        Atomic.decr length;
+        clean_children ~self prm;
+        result
+      in
+      let rec try_attach_all attached = function
+        | node :: nodes ->
+            let attached = node :: attached in
+            if Computation.try_attach (prm_of node).state t then
+              try_attach_all attached nodes
+            else take_one_and_detach_rest nodes attached
+        | [] -> (
+            match Trigger.await t with
+            | Some (exn, bt) ->
+                List.iter
+                  (fun node -> Computation.detach (prm_of node).state t)
+                  attached;
+                Error (exn, bt)
+            | None -> take_one_and_detach_rest [] nodes)
+      in
+      try_attach_all [] nodes
+    in
+    let prm = async choose in
+    miou_assert (await_exn prm);
+    match Computation.await_exn c with
+    | Ok value -> Some (Ok value)
+    | Error (exn, _bt) -> Some (Error exn)
+    | exception _exn -> assert false
+  end
 
 module Hook = struct
   type t = { uid: Domain.Uid.t; node: (unit -> unit) Miou_sequence.node }

--- a/lib/miou.ml
+++ b/lib/miou.ml
@@ -73,6 +73,15 @@ and pack = Pack : 'a t -> pack [@@unboxed]
 module Promise = struct
   module Uid = Promise_uid
 
+  type state = Running | Exited | Finished
+
+  let state : type a. a t -> state =
+   fun prm ->
+    match Atomic.get (prm.state :> a Computation.state Atomic.t) with
+    | Computation.Cancelled _ -> Exited
+    | Computation.Returned _ -> Finished
+    | Computation.Continue _ -> Running
+
   let create ?parent ~forbid ?resources:(ress = []) runner =
     let resources = Miou_sequence.create () in
     List.iter Miou_sequence.(add Left resources) ress;

--- a/lib/miou.mli
+++ b/lib/miou.mli
@@ -727,6 +727,29 @@ val take : 'a orphans -> 'a t option
       As {!val:care}, [take] must be used in the promise that corresponds to the
       parent of the promises held by the given [orphans].*)
 
+val get : 'a orphans -> ('a, exn) result option
+(** [get orphans] behaves like {!val:await_one} but on the promises held by the
+    given [orphans]. It {b blocks} until one of these promises terminates
+    (either normally or with an exception), removes it from the [orphans] and
+    returns its result.
+
+    [None] is returned only if the given [orphans] is empty (there is nothing to
+    wait for). [Some result] is the result of the promise which terminated; that
+    promise is then removed from the internal sequence of the given [orphans]
+    and is no longer its responsibility (it has been consumed). The other
+    promises are {b not} cancelled.
+
+    {[
+    let rec drain orphans =
+      match Miou.get orphans with
+      | None -> ()
+      | Some (Ok _ | Error _) -> drain orphans
+    ]}
+
+    @raise Invalid_argument
+      As {!val:care} and {!val:take}, [get] must be used in the promise that
+      corresponds to the parent of the promises held by the given [orphans]. *)
+
 val length : _ orphans -> int
 (** [length orphans] returns the number of remaining tasks. *)
 

--- a/lib/miou.mli
+++ b/lib/miou.mli
@@ -509,7 +509,14 @@ type 'a t
 
 module Promise : sig
   type nonrec 'a t = 'a t
-  type state = Running | Exited | Finished
+
+  type state =
+    | Running
+    | Exited
+    | Finished
+        (** The status of a promise: it may be in a pending state, or it may
+            have ended abnormally ([Exited]) or successfully ([Finished]). This
+            status is for information purposes only. *)
 
   module Uid : sig
     type t [@@immediate]
@@ -518,7 +525,10 @@ module Promise : sig
   end
 
   val uid : 'a t -> Uid.t
+  (** [uid prm] returns the unique ID of the promise. *)
+
   val state : 'a t -> state
+  (** [state prm] returns the status of a promise. *)
 end
 
 exception No_domain_available

--- a/lib/miou.mli
+++ b/lib/miou.mli
@@ -509,6 +509,7 @@ type 'a t
 
 module Promise : sig
   type nonrec 'a t = 'a t
+  type state = Running | Exited | Finished
 
   module Uid : sig
     type t [@@immediate]
@@ -517,6 +518,7 @@ module Promise : sig
   end
 
   val uid : 'a t -> Uid.t
+  val state : 'a t -> state
 end
 
 exception No_domain_available

--- a/test/test_core.ml
+++ b/test/test_core.ml
@@ -874,6 +874,64 @@ let test45 =
   in
   Miou.await_exn prm; Test.check true
 
+let test46 =
+  let description = {text|Miou.get|text} in
+  Test.test ~title:"test46" ~description @@ fun () ->
+  Miou.run @@ fun () ->
+  let prm =
+    Miou.async @@ fun () ->
+    let orphans = Miou.orphans () in
+    Test.check (Miou.get orphans = None);
+    ignore (Miou.async ~orphans @@ fun () -> 1);
+    ignore (Miou.async ~orphans @@ fun () -> 2);
+    ignore (Miou.async ~orphans @@ fun () -> failwith "t46");
+    Test.check (Miou.length orphans = 3);
+    let oks = ref 0 and errs = ref 0 in
+    let rec drain () =
+      match Miou.get orphans with
+      | None -> ()
+      | Some (Ok _) -> incr oks; drain ()
+      | Some (Error _) -> incr errs; drain ()
+    in
+    drain ();
+    Test.check (Miou.length orphans = 0);
+    Test.check (!oks = 2 && !errs = 1)
+  in
+  Miou.await_exn prm
+
+let test47 =
+  let description = {text|Miou.get: parent error|text} in
+  Test.test ~title:"test47" ~description @@ fun () ->
+  Miou.run @@ fun () ->
+  let orphans = Miou.orphans () in
+  let p = Miou.async ~orphans @@ fun () -> 42 in
+  let bad =
+    Miou.async @@ fun () ->
+    try
+      ignore (Miou.get orphans);
+      false
+    with Invalid_argument _ -> true
+  in
+  Test.check (Miou.await_exn bad);
+  ignore (Miou.await_exn p);
+  ignore (Miou.get orphans)
+
+let test48 =
+  let description = {text|Miou.get: no leak on it|text} in
+  Test.test ~title:"test48" ~description @@ fun () ->
+  Miou.run @@ fun () ->
+  let blocker =
+    Miou.async @@ fun () ->
+    let orphans = Miou.orphans () in
+    ignore (Miou.async ~orphans infinite);
+    ignore (Miou.get orphans)
+  in
+  Miou.yield ();
+  Miou.cancel blocker;
+  match Miou.await blocker with
+  | Error Miou.Cancelled -> Test.check true
+  | _ -> Test.check false
+
 let () =
   let tests =
     [
@@ -882,6 +940,7 @@ let () =
     ; test19; test20; test21; test22; test23; test24; test25; test26; test27
     ; test28; test29; test30; test31; test32; test33; test34; test35; test36
     ; test37; test38; test39; test40; test41; test42; test43; test44; test45
+    ; test46; test47; test48
     ]
   in
   let ({ Test.directory } as runner) =


### PR DESCRIPTION
The first is more interesting than the second. The idea is to be able to `choose`/`await_one` one of the tasks available into the given `orphans`. Such pattern is required by `mnet-ssh` which spawns tasks and would like to way the first one which finished (see [this equivalent with lwt](https://github.com/mirage/awa-ssh/blob/main/mirage/awa_mirage.ml#L350)).