### PR TITLE
Be able to catch errors for suspensions like Unix.connect

### DIFF
--- a/lib/miou_unix.poll.ml
+++ b/lib/miou_unix.poll.ml
@@ -513,6 +513,14 @@ let transmit_and_clean domain syscall =
   Hashtbl.remove domain.revert (Miou.uid syscall);
   Miou.signal syscall
 
+let wakeup domain tbl fd =
+  match File_descrs.find_opt tbl fd with
+  | None -> []
+  | Some [] -> File_descrs.remove tbl fd; []
+  | Some syscalls ->
+      File_descrs.remove tbl fd;
+      List.rev_map (transmit_and_clean domain) syscalls
+
 let select _uid ic ~block cancelled_syscalls =
   let domain = domain () in
   clean domain cancelled_syscalls;
@@ -532,51 +540,18 @@ let select _uid ic ~block cancelled_syscalls =
       let acc = ref (collect domain []) in
       let fn index fd flags =
         if index == 0 then intr ic
-        else if Poll.Flags.mem flags Poll.Flags.(pollin + pollhup) then (
-          Poll.invalidate_index domain.poll index;
-          Bitv.set domain.bitv index false;
-          match File_descrs.find_opt domain.readers fd with
-          | None -> ()
-          | Some [] -> File_descrs.remove domain.readers fd
-          | Some syscalls ->
-              File_descrs.remove domain.readers fd;
-              acc :=
-                List.rev_append
-                  (List.rev_map (transmit_and_clean domain) syscalls)
-                  !acc)
-        else if Poll.Flags.mem flags Poll.Flags.pollout then (
-          Poll.invalidate_index domain.poll index;
-          Bitv.set domain.bitv index false;
-          match File_descrs.find_opt domain.writers fd with
-          | None -> ()
-          | Some [] -> File_descrs.remove domain.writers fd
-          | Some syscalls ->
-              File_descrs.remove domain.writers fd;
-              acc :=
-                List.rev_append
-                  (List.rev_map (transmit_and_clean domain) syscalls)
-                  !acc)
-        else if Poll.Flags.(mem flags (pollerr + pollnval)) then (
-          Poll.invalidate_index domain.poll index;
-          Bitv.set domain.bitv index false;
-          (match File_descrs.find_opt domain.readers fd with
-          | None -> ()
-          | Some [] -> File_descrs.remove domain.readers fd
-          | Some syscalls ->
-              File_descrs.remove domain.readers fd;
-              acc :=
-                List.rev_append
-                  (List.rev_map (transmit_and_clean domain) syscalls)
-                  !acc);
-          match File_descrs.find_opt domain.writers fd with
-          | None -> ()
-          | Some [] -> File_descrs.remove domain.writers fd
-          | Some syscalls ->
-              File_descrs.remove domain.writers fd;
-              acc :=
-                List.rev_append
-                  (List.rev_map (transmit_and_clean domain) syscalls)
-                  !acc)
+        else begin
+          let err = Poll.Flags.(mem flags (pollerr + pollhup + pollnval)) in
+          let readable = err || Poll.Flags.mem flags Poll.Flags.pollin in
+          let writable = err || Poll.Flags.mem flags Poll.Flags.pollout in
+          if readable || writable then begin
+            Poll.invalidate_index domain.poll index;
+            Bitv.set domain.bitv index false;
+            let x = if readable then wakeup domain domain.readers fd else [] in
+            let y = if writable then wakeup domain domain.writers fd else [] in
+            acc := List.rev_append y (List.rev_append x !acc)
+          end
+        end
       in
       Poll.iter domain.poll nready fn;
       !acc

--- a/test/test_unix.ml
+++ b/test/test_unix.ml
@@ -138,11 +138,32 @@ let test_udp_stream_mismatch =
   Miou_unix.close udp;
   Miou_unix.close tcp
 
+let test_connect_refused =
+  let description = {text|A failing connect must signal the writer|text} in
+  Test.test ~title:"connect refused" ~description @@ fun () ->
+  Miou_unix.run ~domains:0 @@ fun () ->
+  let m = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Unix.bind m (Unix.ADDR_INET (Unix.inet_addr_loopback, 0));
+  let sockaddr = Unix.getsockname m in
+  Unix.close m;
+  let socket = Miou_unix.tcpv4 () in
+  let connect =
+    Miou.async @@ fun () ->
+    match Miou_unix.connect socket sockaddr with
+    | () -> `Connected
+    | exception Unix.Unix_error (Unix.ECONNREFUSED, _, _) -> `Refused
+  and timeout = Miou.async @@ fun () -> Miou_unix.sleep 2.; `Timeout in
+  let jobs = [ connect; timeout ] in
+  let result = Miou.await_one jobs in
+  List.iter Miou.cancel jobs;
+  Miou_unix.close socket;
+  Test.check (result = Ok `Refused)
+
 let () =
   let tests =
     [|
        test_eof_on_pipe; test_create_process; test_udp_echo
-     ; test_udp_stream_mismatch
+     ; test_udp_stream_mismatch; test_connect_refused
     |]
   in
   let ({ Test.directory } as runner) =

--- a/test/test_unix.ml
+++ b/test/test_unix.ml
@@ -4,9 +4,9 @@ let system =
   ignore (Unix.close_process_in ic);
   system
 
-let test_eof_on_pipe =
+let test01 =
   let description = {text|Test waiting for EOF|text} in
-  Test.test ~title:"eof on pipe" ~description @@ fun () ->
+  Test.test ~title:"test01" ~description @@ fun () ->
   Miou_unix.run ~domains:0 @@ fun () ->
   let cmd = "true" in
   let out, cmd_stdout = Unix.pipe ~cloexec:true () in
@@ -45,9 +45,9 @@ let test_eof_on_pipe =
   end;
   List.iter Miou.cancel jobs
 
-let test_create_process =
+let test02 =
   let description = {text|Unix.create_process|text} in
-  Test.test ~title:"create process" ~description @@ fun () ->
+  Test.test ~title:"test02" ~description @@ fun () ->
   let buf = Buffer.create 0x7ff in
   let prgm () =
     Miou_unix.run ~domains:0 @@ fun () ->
@@ -79,9 +79,9 @@ let test_create_process =
       let expected = "sleep launched\nsignal handler installed\nWEXITED(0)\n" in
       Test.check (serialized = expected)
 
-let test_udp_echo =
+let test03 =
   let description = {text|A simple echo with sendto/recvfrom|text} in
-  Test.test ~title:"echo" ~description @@ fun () ->
+  Test.test ~title:"test03" ~description @@ fun () ->
   Miou_unix.run ~domains:0 @@ fun () ->
   let server = Miou_unix.udpv4 () in
   Miou_unix.bind_and_listen server (Unix.ADDR_INET (Unix.inet_addr_loopback, 0));
@@ -113,9 +113,9 @@ let test_udp_echo =
   Test.check (b = String.length (String.uppercase_ascii payload));
   Test.check (y = String.uppercase_ascii payload)
 
-let test_udp_stream_mismatch =
+let test04 =
   let description = {text|TCP/UDP guards|text} in
-  Test.test ~title:"udp and tcp" ~description @@ fun () ->
+  Test.test ~title:"test04" ~description @@ fun () ->
   Miou_unix.run ~domains:0 @@ fun () ->
   let exn fn =
     match fn () with
@@ -138,9 +138,9 @@ let test_udp_stream_mismatch =
   Miou_unix.close udp;
   Miou_unix.close tcp
 
-let test_connect_refused =
+let test05 =
   let description = {text|A failing connect must signal the writer|text} in
-  Test.test ~title:"connect refused" ~description @@ fun () ->
+  Test.test ~title:"test05" ~description @@ fun () ->
   Miou_unix.run ~domains:0 @@ fun () ->
   let m = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
   Unix.bind m (Unix.ADDR_INET (Unix.inet_addr_loopback, 0));
@@ -160,12 +160,7 @@ let test_connect_refused =
   Test.check (result = Ok `Refused)
 
 let () =
-  let tests =
-    [|
-       test_eof_on_pipe; test_create_process; test_udp_echo
-     ; test_udp_stream_mismatch; test_connect_refused
-    |]
-  in
+  let tests = [| test01; test02; test03; test04; test05 |] in
   let ({ Test.directory } as runner) =
     Test.runner (Filename.concat (Sys.getcwd ()) "_tests")
   in


### PR DESCRIPTION
This patch adds a test and recognize when an error occurred for a specific file-descriptor. In that case, we de-suspend our syscall and let the user to deal with the error. It's not tested on Windows, let's see how our `Unix.select` reacts with our test.