### PR TITLE
Fix how our dom0 waits other domains to terminate and avoid a busy-loop

### DIFF
--- a/lib/miou.ml
+++ b/lib/miou.ml
@@ -430,6 +430,7 @@ type signal_retrieved =
   | Signal_retrieved : int * (int -> unit) -> signal_retrieved
 
 let signals = Queue.create ()
+let dom0_interrupt = Atomic.make ignore
 
 let transfer_dom0_signals pool =
   if not (Queue.is_empty signals) then begin
@@ -459,6 +460,8 @@ module Domain = struct
     ; hooks= Miou_sequence.create ()
     }
 
+  (* NOTE(dinosaure): as far as [event.interrupt] is domain-safe (which should
+     be the case), [interrupt] is domain-safe. *)
   let interrupt pool ~domain:uid =
     let runner = Domain_uid.of_int (Stdlib.Domain.self () :> int) in
     Logs.debug (fun m ->
@@ -1792,7 +1795,8 @@ let sys_signal signal = function
       let fn signal =
         Logs.debug (fun m ->
             m "[%d] got a signal %d" (Stdlib.Domain.self () :> int) signal);
-        Queue.enqueue signals (Signal_retrieved (signal, fn))
+        Queue.enqueue signals (Signal_retrieved (signal, fn));
+        if (Stdlib.Domain.self () :> int) <> 0 then Atomic.get dom0_interrupt ()
       in
       Sys.signal signal (Signal_handle fn)
 
@@ -1801,6 +1805,10 @@ let run ?(quanta = quanta) ?(g = Random.State.make_self_init ())
   Promise_uid.reset ();
   let dom0 = Domain_uid.of_int 0 in
   let dom0 = Domain.create ~quanta ~events g dom0 in
+  (* NOTE(dinosaure): set [dom0_interrupt] used by [sys_signal] to be able to
+     wake-up [dom0] if it is on the sleeping mode and when we retrieve a signal
+     on another domain. *)
+  Atomic.set dom0_interrupt dom0.events.interrupt;
   let prm0 = Promise.create ~forbid:false dom0.uid in
   Domain.add_into_domain dom0 (Domain_create (prm0, fn));
   let pool, domains = Pool.create ~quanta ~dom0 ~domains ~events () in
@@ -1821,6 +1829,7 @@ let run ?(quanta = quanta) ?(g = Random.State.make_self_init ())
       Error (exn, bt)
   in
   Pool.kill pool;
+  Atomic.set dom0_interrupt ignore;
   dom0.events.finaliser ();
   List.iter Stdlib.Domain.join domains;
   match result with

--- a/lib/miou.ml
+++ b/lib/miou.ml
@@ -41,6 +41,7 @@ exception Not_a_child
 exception No_domain_available
 exception Not_owner
 exception Resource_leaked
+exception No_select_provided
 
 let () =
   Printexc.register_printer @@ function
@@ -975,6 +976,21 @@ module Domain = struct
     | exception Heapq.Empty ->
         if system_events_suspended domain then
           unblock_awaits_with_system_events pool domain
+        else if (domain.uid :> int) = 0 then
+          (* NOTE(dinosaure): [dom0] has an empty run-queue and no pending
+             syscall: [prm0] is waiting for completions coming from other
+             domains. Without this branch, [run] returns immediately and the
+             toplevel loop of [Miou.run] busy-waits at 100% CPU until a worker
+             resolves what [prm0] awaits. Blocking into
+             [events.select ~block:true] is safe here: every cross-domain
+             completion goes through [add_into_dom0] which wakes [dom0] up with
+             [events.interrupt] (so does the failure path of the pool).
+
+             NOTE(dinosaure): Backends without a select function (pure
+             [Miou.run]) keep the historical spinning behaviour for our tests. *)
+          begin try unblock_awaits_with_system_events pool domain
+          with No_select_provided -> ()
+          end
     | _, elt ->
         once pool domain elt;
         if system_events_suspended domain then
@@ -1759,8 +1775,6 @@ let error_select =
    (which does not handle system events). You should use Miou_unix.run if you \
    use functions proposed by the Miou_unix module or use your own run function \
    associated with your suspensions."
-
-exception No_select_provided
 
 let () =
   Printexc.register_printer @@ function

--- a/lib/miou.mli
+++ b/lib/miou.mli
@@ -411,21 +411,6 @@
     In both cases and in such a situation, an exception is thrown:
     {!exception:No_domain_available}.
 
-    {5 [dom0] and its role.}
-
-    It is worth noting the specific nature of the [dom0]. Although the user may
-    wish to run all their tasks in parallel on the other domains, if the [dom0]
-    is not involved in a job (via {!val:Miou.async}), it will remain in a
-    {i burning-loop} state (100% CPU usage) even whilst waiting for the results
-    of the parallel tasks.
-
-    This is {b expected} behaviour, although counterintuitive. The fact is that
-    the [dom0] monitors several events (such as signals), the domains and their
-    results.
-
-    It is therefore advisable to involve the [dom0] in the work via at least one
-    {!val:Miou.async}.
-
     {4 Rule 7, suspension points are local to the domain.}
 
     A suspension point is local to the domain. This means that only the domain


### PR DESCRIPTION
Instead of just waiting a new state from our internal `prm0`, we enter our `dom0` into the sleeping mode **only** when we have a backend (when we specify a `~events`) to avoid a busy loop. We should trust then our interrupt mechanism to wake-up our `dom0` when one of your domains terminated something.

I think some people observed such busy-loop (/cc @voodoos), see #104. I need to test few programs before to merge.