### PR TITLE
Be exhaustive on our pattern matching to pick a new task

### DIFF
--- a/lib/miou.ml
+++ b/lib/miou.ml
@@ -784,8 +784,12 @@ module Domain = struct
     let elts = ref [] in
     let f = function
       | _, Domain_tick _ -> .
-      | _, Domain_cancel _ | _, Domain_clean _ | _, Domain_signal _ -> ()
-      | _, elt ->
+      | _, Domain_cancel _
+      | _, Domain_clean _
+      | _, Domain_signal _
+      | _, Domain_transfer _ ->
+          ()
+      | _, ((Domain_create _ | Domain_task _) as elt) ->
           let (Pack prm) = promise_of_domain_elt elt in
           if Promise_uid.equal prm.uid uid then elts := elt :: !elts
     in


### PR DESCRIPTION
Because I forgot [Domain_transfer], we may encounter an [assert false] case in the [get_elt_into_domain] function. This patch assumes that the pattern matching is exhaustive.