### PR TITLE
Enforce assumptions on `Miou.Ownership` module

### DIFF
--- a/lib/miou.ml
+++ b/lib/miou.ml
@@ -532,6 +532,14 @@ module Domain = struct
     | 0, _ -> miou_assert false
     | _ -> add_into_pool pool (Pool_cancel (prm, bt))
 
+  let release_resource domain prm (Resource { uid; value; finaliser }) =
+    try finaliser value
+    with exn ->
+      Logs.err (fun m ->
+          m "[%a] unexpected exception from the finaliser of [%a](%a): %s"
+            Domain_uid.pp domain.uid Resource_uid.pp uid Promise.pp prm
+            (Printexc.to_string exn))
+
   (* NOTE(dinosaure): [handle] is actually idempotent which means that it does
      things according to the given [state] only once. It's especially true for
      [State.Finished (Error _)] and [State.Finished (Ok _)] where some
@@ -568,20 +576,11 @@ module Domain = struct
     | State.Finished (Error (exn, bt)) ->
         if Atomic.compare_and_set prm.finalized false true then begin
           Event.run_done prm;
-          let f (Resource { uid; value; finaliser }) =
-            try finaliser value
-            with exn ->
-              Logs.err (fun m ->
-                  m
-                    "[%a] unexpected exception from the finaliser of [%a](%a): \
-                     %s"
-                    Domain_uid.pp domain.uid Resource_uid.pp uid Promise.pp prm
-                    (Printexc.to_string exn))
-          in
           Logs.debug (fun m ->
               m "[%a] finished a promise %a with exception %s\n%s" Domain_uid.pp
                 domain.uid Promise.pp prm (Printexc.to_string exn)
                 (Printexc.raw_backtrace_to_string bt));
+          let f = release_resource domain prm in
           Miou_sequence.iter ~f prm.resources;
           Miou_sequence.drop prm.resources;
           let f (Pack prm) = cancel pool domain ~backtrace:bt prm in
@@ -592,16 +591,7 @@ module Domain = struct
         end
     | State.Finished (Ok value) ->
         if Miou_sequence.is_empty prm.resources = false then begin
-          let f (Resource { uid; value; finaliser }) =
-            try finaliser value
-            with exn ->
-              Logs.err (fun m ->
-                  m
-                    "[%a] unexpected exception from the finaliser of [%a](%a): \
-                     %s"
-                    Domain_uid.pp domain.uid Resource_uid.pp uid Promise.pp prm
-                    (Printexc.to_string exn))
-          in
+          let f = release_resource domain prm in
           Miou_sequence.iter ~f prm.resources;
           Miou_sequence.drop prm.resources;
           Event.resource_leaked prm;

--- a/lib/miou.ml
+++ b/lib/miou.ml
@@ -903,7 +903,8 @@ module Domain = struct
             else add_into_domain domain (Domain_task (prm, state)))
     | Domain_clean (prm, child) -> clean_children ~self:prm child
     | Domain_transfer (prm, res, trigger) ->
-        Miou_sequence.(add Left) prm.resources res;
+        if Atomic.get prm.finalized then release_resource domain prm res
+        else Miou_sequence.(add Left) prm.resources res;
         Trigger.signal trigger
     | Domain_signal (prm, signal, state) -> (
         miou_assert (Domain_uid.equal prm.runner (Domain_uid.of_int 0));

--- a/lib/miou.ml
+++ b/lib/miou.ml
@@ -540,6 +540,27 @@ module Domain = struct
             Domain_uid.pp domain.uid Resource_uid.pp uid Promise.pp prm
             (Printexc.to_string exn))
 
+  (* NOTE(dinosaure): there may be a situation where a task no longer has the
+     resources and attempts to pass them on to its child (via [~give]), but that
+     child has not yet been executed (or, worse still, the task is cancelled
+     before it even runs).
+
+     In this specific case, the [Spawn] effect has resources that will never be
+     released; these must be released if [prm.finalized] has not been set
+     correctly. *)
+  let release_resources_in_flight domain prm = function
+    | State.Suspended (_, Spawn (_, _, resources, _))
+      when Atomic.get prm.finalized = false ->
+        let f (Resource { uid; _ } as res) =
+          let equal (Resource { uid= uid'; _ }) = Resource_uid.equal uid uid' in
+          (* [not (exists equal resources)] takes the resources that exist in
+             [Spawn] but do not yet exist in [prm.resources]. *)
+          if not (Miou_sequence.exists equal prm.resources) then
+            release_resource domain prm res
+        in
+        List.iter f resources
+    | _ -> ()
+
   (* NOTE(dinosaure): [handle] is actually idempotent which means that it does
      things according to the given [state] only once. It's especially true for
      [State.Finished (Error _)] and [State.Finished (Ok _)] where some
@@ -854,6 +875,7 @@ module Domain = struct
             Event.run_end prm;
             handle pool domain prm state
         | Some (exn, bt) ->
+            release_resources_in_flight domain prm state;
             let state = State.fail ~backtrace:bt ~exn state in
             if Miou_sequence.is_empty prm.children then begin
               Atomic.set prm.cleaned true;
@@ -875,6 +897,7 @@ module Domain = struct
             Event.run_end prm;
             handle_signal ~signal domain prm state
         | Some (exn, bt) ->
+            release_resources_in_flight domain prm state;
             let state = State.fail ~backtrace:bt ~exn state in
             handle_signal ~signal domain prm state)
     | Domain_cancel (prm, bt) as cancellation ->
@@ -896,6 +919,7 @@ module Domain = struct
           | Some (Domain_task (prm', state)) ->
               miou_assert (Promise_uid.equal prm.uid prm'.uid);
               miou_assert (Domain_uid.equal prm.runner domain.uid);
+              release_resources_in_flight domain prm' state;
               let state = State.fail ~backtrace:bt ~exn:Cancelled state in
               handle pool domain prm' state
           | Some (Domain_cancel _)

--- a/lib/miou.ml
+++ b/lib/miou.ml
@@ -287,6 +287,19 @@ type _ Effect.t += Cancel : Printexc.raw_backtrace * 'a t -> unit Effect.t
 type _ Effect.t += Yield : unit Effect.t
 type _ Effect.t += Transfer : resource -> Trigger.t Effect.t
 
+let free =
+  let free : type a. a Effect.t -> bool = function
+    | Self | Self_domain | Random | Domains -> true
+    | _ -> false
+  in
+  { State.free }
+(* NOTE(dinosaure): It is assumed that certain effects have no impact on the
+   scheduler and how it works, and are considered {i pure}. For this type of
+   effect, we do not want them to consume an {i quanta}, and their use assumes
+   the atomicity of an operation from the user's perspective (in the sense that
+   a [Effect.perform] of these effects {b does not suspend}). It is important to
+   bear in mind that, by default, all effects suspend. *)
+
 let[@coverage off] pp_effect : type a. a Effect.t Fmt.t =
  fun ppf -> function
   | Spawn _ -> Fmt.string ppf "Spawn"
@@ -436,17 +449,6 @@ type signal_retrieved =
 
 let signals = Queue.create ()
 let dom0_interrupt = Atomic.make ignore
-
-let transfer_dom0_signals pool =
-  if not (Queue.is_empty signals) then begin
-    let elts = Queue.transfer signals in
-    let f (Signal_retrieved (signal, fn)) =
-      let prm = Promise.create ~forbid:true pool.dom0.uid in
-      let state = State.make fn signal in
-      add_into_domain pool.dom0 (Domain_signal (prm, signal, state))
-    in
-    Queue.iter ~f elts
-  end
 
 module Domain = struct
   module Uid = Domain_uid
@@ -839,6 +841,20 @@ module Domain = struct
               domain.uid (Printexc.to_string exn))
     | State.Finished (Ok ()) -> ()
 
+  let transfer_dom0_signals pool =
+    if not (Queue.is_empty signals) then begin
+      let elts = Queue.transfer signals in
+      let f (Signal_retrieved (signal, fn)) =
+        let prm = Promise.create ~forbid:true pool.dom0.uid in
+        let state = State.make fn signal in
+        let perform = perform pool pool.dom0 prm in
+        (* NOTE(dinosaure): we consume {i free} effects here. *)
+        let state = State.drain ~free ~perform state in
+        add_into_domain pool.dom0 (Domain_signal (prm, signal, state))
+      in
+      Queue.iter ~f elts
+    end
+
   let once pool domain = function
     | Domain_tick _ -> .
     | Domain_create (prm, fn) -> (
@@ -846,6 +862,9 @@ module Domain = struct
         | None ->
             Event.run_begin prm;
             let state = State.make fn () in
+            let perform = perform pool domain prm in
+            (* NOTE(dinosaure): we consume {i free} effects here. *)
+            let state = State.drain ~free ~perform state in
             Event.run_end prm;
             handle pool domain prm state
         | Some (exn, bt) ->
@@ -871,7 +890,7 @@ module Domain = struct
                violation of our rules, namely that only the domain in charge of
                the promise can continue the continuation [k]. *)
             Event.run_begin prm;
-            let state = State.run ~quanta:domain.quanta ~perform state in
+            let state = State.run ~quanta:domain.quanta ~free ~perform state in
             Event.run_end prm;
             handle pool domain prm state
         | Some (exn, bt) ->
@@ -893,7 +912,7 @@ module Domain = struct
         match Computation.cancelled prm.state with
         | None ->
             Event.run_begin prm;
-            let state = State.run ~quanta:domain.quanta ~perform state in
+            let state = State.run ~quanta:domain.quanta ~free ~perform state in
             Event.run_end prm;
             handle_signal ~signal domain prm state
         | Some (exn, bt) ->
@@ -1839,7 +1858,7 @@ let run ?(quanta = quanta) ?(g = Random.State.make_self_init ())
     try
       while Computation.is_running prm0.state && !(pool.fail) = false do
         transfer_dom0_tasks pool;
-        transfer_dom0_signals pool;
+        Domain.transfer_dom0_signals pool;
         Domain.run pool dom0
       done;
       if not !(pool.fail) then Option.get (Computation.peek prm0.state)

--- a/lib/miou_state.ml
+++ b/lib/miou_state.ml
@@ -104,10 +104,34 @@ exception Break
 
 let is_finished = function Finished _ -> true | _ -> false
 
+type free = { free: 'a. 'a Effect.t -> bool } [@@unboxed]
+
+let never = { free= (fun _ -> false) }
+
+let is_free free = function
+  | Suspended (_, eff) -> free.free eff
+  | Finished _ | Unhandled _ -> false
+
 [@@@warning "-8"]
 
-let run : type a. quanta:int -> perform:perform -> a t -> a t =
- fun ~quanta ~perform state ->
+let rec drain : type a. free:free -> perform:perform -> a t -> a t =
+ fun ~free ~perform state ->
+  match state with
+  | Suspended (fn, e) when free.free e ->
+      let k : type c. (c, a) continuation -> c Operation.t -> a t =
+       fun fn -> function
+         | Return v -> continue_with fn v
+         | Fail (exn, bt) -> discontinue_with ~backtrace:bt fn exn
+         | Continue e -> suspended_with fn e
+         | Perform e -> unhandled_with fn (Effect.perform e)
+         | Yield -> continue_with fn ()
+         | Interrupt -> state
+      in
+      drain ~free ~perform (perform.perform (k fn) e)
+  | state -> state
+
+let run : type a. quanta:int -> ?free:free -> perform:perform -> a t -> a t =
+ fun ~quanta ?(free = never) ~perform state ->
   let exception Yield of a t in
   let k : type c. (c, a) continuation -> c Operation.t -> a t =
    fun fn -> function
@@ -122,11 +146,11 @@ let run : type a. quanta:int -> perform:perform -> a t -> a t =
   in
   let quanta = ref quanta and state = ref state in
   try
-    while !quanta > 0 && is_finished !state = false do
+    while (!quanta > 0 || is_free free !state) && is_finished !state = false do
       match !state with
       | Suspended (fn, e) ->
           state := perform.perform (k fn) e;
-          quanta := !quanta - 1
+          quanta := !quanta - if free.free e then 0 else 1
       | Unhandled (fn, v) ->
           state := continue_with fn v;
           quanta := !quanta - 1
@@ -134,7 +158,7 @@ let run : type a. quanta:int -> perform:perform -> a t -> a t =
     !state
   with
   | Break -> !state
-  | Yield state -> state
+  | Yield state -> drain ~free ~perform state
   | exn ->
       Logs.err (fun m -> m "Unexpected exception: %S" (Printexc.to_string exn));
       raise exn

--- a/lib/miou_state.mli
+++ b/lib/miou_state.mli
@@ -43,6 +43,11 @@ type perform = { perform: 'a 'b. ('a, 'b) handler } [@@unboxed]
     [perform] is a function which should handle incoming effects and give an
     {i operation} {!type:Operation.t} via the given continuation [k]. *)
 
+type free = { free: 'a. 'a Effect.t -> bool } [@@unboxed]
+(** Predicate describing {i free} effects: pure queries on the scheduler's
+    state, which cost no {i quanta} and on which a task must never be suspended.
+*)
+
 val make : ('a -> 'b) -> 'a -> 'b t
 (** [make fn value] makes a new {i function state} by executing the function
     with the given argument. *)
@@ -67,7 +72,7 @@ val fail : backtrace:Printexc.raw_backtrace -> exn:exn -> 'a t -> 'a t
 val pure : ('a, error) result -> 'a t
 (** [pure value] returns [Finished value]. *)
 
-val run : quanta:int -> perform:perform -> 'a t -> 'a t
+val run : quanta:int -> ?free:free -> perform:perform -> 'a t -> 'a t
 (** [run ~quanta ~perform state] applies {!val:once} [quanta] times. If
     [perform] responds with {!val:Operation.interrupt} (and therefore does
     nothing), even though there may be a few {i quanta} left, the function
@@ -76,6 +81,10 @@ val run : quanta:int -> perform:perform -> 'a t -> 'a t
     The same applies to {!val:Operation.yield}, except that the continuation has
     burnt itself out. In other words, {!val:Operation.yield} is equivalent to
     [send (); interrupt] but costs only one {i quanta}. *)
+
+val drain : free:free -> perform:perform -> 'a t -> 'a t
+(** [drain ~free ~perform] advances the given state as long as it is suspended
+    on a {i free} effect. In our terms, [drain] consumes 0 {i quanta}. *)
 
 (**/**)
 

--- a/test/test_core.ml
+++ b/test/test_core.ml
@@ -1087,6 +1087,31 @@ let test54 =
   in
   List.iter fn prms; Test.check !released
 
+let test55 =
+  let description =
+    {text|Cancelling a task while a child transfers a resource.|text}
+  in
+  Test.test ~title:"test55" ~description @@ fun () ->
+  let released = Atomic.make 0 and total = ref 0 in
+  for n = 0 to 8 do
+    for k = 0 to 8 do
+      Miou.run @@ fun () ->
+      let prm =
+        Miou.async @@ fun () ->
+        let finally () = Atomic.incr released in
+        let t = Miou.Ownership.create ~finally () in
+        let _ =
+          Miou.call ~give:[ t ] @@ fun () ->
+          (* no-op, transfer & infinite *)
+          yield k; Miou.Ownership.transfer t; infinite ()
+        in
+        infinite ()
+      in
+      yield n; Miou.cancel prm; yield 10; incr total
+    done
+  done;
+  Test.check (Atomic.get released = !total)
+
 let () =
   let tests =
     [
@@ -1096,6 +1121,7 @@ let () =
     ; test28; test29; test30; test31; test32; test33; test34; test35; test36
     ; test37; test38; test39; test40; test41; test42; test43; test44; test45
     ; test46; test47; test48; test49; test50; test51; test52; test53; test54
+    ; test55
     ]
   in
   let ({ Test.directory } as runner) =

--- a/test/test_core.ml
+++ b/test/test_core.ml
@@ -758,12 +758,9 @@ let test38 =
     Miou.yield (); Miou.Hook.remove node2; Miou.Hook.remove node1
   in
   prgm ();
-  (* - h1 from Miou.Hook.add h2
-     - h2 from Miou.yield
-     - h1 from Miou.yield
-     - h1 from Miou.Hook.remove node2
-     - h1 from Miou.Hook.remove node1 *)
-  Test.check (Buffer.contents buf = "h1\nh2\nh1\nh1\nh1\n")
+  (* - h2 from Miou.yield (then removed, it raised)
+     - h1 from Miou.yield *)
+  Test.check (Buffer.contents buf = "h2\nh1\n")
 
 let test39 =
   let description =

--- a/test/test_core.ml
+++ b/test/test_core.ml
@@ -105,6 +105,11 @@ let test08 =
 
 let rec infinite () = infinite (Miou.yield ())
 
+let yield n =
+  for _ = 1 to n do
+    Miou.yield ()
+  done
+
 let test09 =
   let description = {text|A test to show up the cancellation.|text} in
   Test.test ~title:"test09" ~description @@ fun () ->
@@ -929,6 +934,159 @@ let test48 =
   | Error Miou.Cancelled -> Test.check true
   | _ -> Test.check false
 
+let owned_resource_is_always_released ~n ~k =
+  let owned = Atomic.make 0 and released = Atomic.make 0 in
+  let prgm () =
+    Miou.run @@ fun () ->
+    let prm =
+      Miou.async @@ fun () ->
+      yield k;
+      let finally () = Atomic.incr released in
+      let t = Miou.Ownership.create ~finally () in
+      Atomic.incr owned; Miou.Ownership.own t; infinite ()
+    in
+    yield n;
+    Miou.cancel prm;
+    match Miou.await prm with
+    | Error Miou.Cancelled -> ()
+    | _ -> failwith "Unexpected state of prm"
+  in
+  prgm ();
+  (Atomic.get owned, Atomic.get released)
+
+let test49 =
+  let description = {text|Miou.Ownership.own is atomic.|text} in
+  Test.test ~title:"test49" ~description @@ fun () ->
+  let owned = ref 0 in
+  let released = ref true in
+  for n = 0 to 8 do
+    for k = 0 to 8 do
+      let a, b = owned_resource_is_always_released ~n ~k in
+      released := !released && a = b;
+      owned := !owned + a
+    done
+  done;
+  (* NOTE(dinosaure): we should always reach a point where we own, at least, one
+     resource (or we are not lucky). *)
+  Test.check (!owned > 0);
+  Test.check !released
+
+let test50 =
+  let description = {text|Resources and parallel tasks.|text} in
+  Test.test ~title:"test50" ~description @@ fun () ->
+  let owned = Atomic.make 0 and released = Atomic.make 0 in
+  let prm () =
+    let finally () = Atomic.incr released in
+    let t = Miou.Ownership.create ~finally () in
+    Atomic.incr owned; Miou.Ownership.own t; infinite ()
+  in
+  let g = Random.State.make [| 0xdeadbeef |] in
+  Miou.run @@ fun () ->
+  for _ = 1 to 200 do
+    let prm =
+      match Random.State.bool g with
+      | true -> Miou.call prm
+      | false -> Miou.async prm
+    in
+    yield (Random.State.int g 12);
+    Miou.cancel prm;
+    match Miou.await prm with
+    | Error Miou.Cancelled -> ()
+    | _ -> failwith "Unexpected state of prm"
+  done;
+  Test.check (Atomic.get owned > 0);
+  Test.check (Atomic.get owned = Atomic.get released)
+
+let test51 =
+  let description = {text|Miou.Ownership.release runs finalizer once.|text} in
+  Test.test ~title:"test51" ~description @@ fun () ->
+  let released = Atomic.make 0 in
+  Miou.run @@ fun () ->
+  let prm =
+    Miou.async @@ fun () ->
+    let finally () = Atomic.incr released in
+    let t = Miou.Ownership.create ~finally () in
+    Miou.Ownership.own t; Miou.Ownership.release t
+  in
+  Miou.await_exn prm;
+  Test.check (Atomic.get released = 1)
+
+let test52 =
+  let description = {text|Finalizer called when we have exception.|text} in
+  Test.test ~title:"test52" ~description @@ fun () ->
+  let released = Atomic.make 0 in
+  Miou.run @@ fun () ->
+  let finally () = Atomic.incr released in
+  let t = Miou.Ownership.create ~finally () in
+  let prm = Miou.async ~give:[ t ] infinite in
+  Miou.yield ();
+  Miou.cancel prm;
+  match Miou.await prm with
+  | Error Miou.Cancelled -> Test.check (Atomic.get released = 1)
+  | _ -> failwith "Unexpected state of prm"
+
+let test53 =
+  let description =
+    {text|Finalizer called when we have exception (even with children).|text}
+  in
+  Test.test ~title:"test53" ~description @@ fun () ->
+  let released = Atomic.make 0 in
+  let prgm () =
+    Miou.run @@ fun () ->
+    let prm =
+      Miou.async @@ fun () ->
+      let finally () = Atomic.incr released in
+      let t = Miou.Ownership.create ~finally () in
+      Miou.Ownership.own t;
+      ignore (Miou.async infinite);
+      Miou.yield ();
+      failwith "prm"
+    in
+    Miou.await_exn prm
+  in
+  match prgm () with
+  | () -> failwith "Unexpected state of prm"
+  | exception Failure _ -> Test.check (Atomic.get released = 1)
+  | exception _ -> Test.check false
+
+let given_resource_is_always_released ~n fn =
+  let released = Atomic.make 0 in
+  Miou.run @@ fun () ->
+  let prm =
+    Miou.async @@ fun () ->
+    let finally () = Atomic.incr released in
+    let t = Miou.Ownership.create ~finally () in
+    fn t; infinite ()
+  in
+  yield n;
+  Miou.cancel prm;
+  match Miou.await prm with
+  | Error Miou.Cancelled -> yield 10; Atomic.get released
+  | _ -> failwith "Unexpected state of prm"
+
+let test54 =
+  let description =
+    {text|We can safely give resource even if we cancel.|text}
+  in
+  Test.test ~title:"test54" ~description @@ fun () ->
+  let prms =
+    [
+      (fun t -> ignore (Miou.async ~give:[ t ] infinite))
+    ; (fun t -> ignore (Miou.call ~give:[ t ] infinite))
+    ; (fun t ->
+        Miou.Ownership.own t;
+        ignore (Miou.async ~give:[ t ] infinite))
+    ]
+  in
+  let released = ref true in
+  let fn fn =
+    for n = 0 to 8 do
+      let x = given_resource_is_always_released ~n fn in
+      released := !released && x = 1
+    done
+  in
+  List.iter fn prms; Test.check !released
+
 let () =
   let tests =
     [
@@ -937,7 +1095,7 @@ let () =
     ; test19; test20; test21; test22; test23; test24; test25; test26; test27
     ; test28; test29; test30; test31; test32; test33; test34; test35; test36
     ; test37; test38; test39; test40; test41; test42; test43; test44; test45
-    ; test46; test47; test48
+    ; test46; test47; test48; test49; test50; test51; test52; test53; test54
     ]
   in
   let ({ Test.directory } as runner) =


### PR DESCRIPTION
This is a second, more polished version of the `Miou.Ownership` module, in which we aim to meet the expectations we have regarding finalisers. In fact, there are currently some memory leaks in `Miou.Ownership`, and this PR aims to fix them (particularly with regard to cancellation).