### PR TITLE
Fix the documentation about how Miou reacts with effects

### DIFF
--- a/lib/miou.mli
+++ b/lib/miou.mli
@@ -56,7 +56,7 @@
     {[
     val my_program : unit -> unit
 
-    let () = Miou.run my_program ()
+    let () = Miou.run my_program
     ]}
 
     {3 A task manager.}
@@ -219,10 +219,9 @@
     {i increase} the points of cooperation that the fibers can emit. This is how
     Miou came up with a fundamental rule: {b an effect yields}.
 
-    All effects (those defined by Miou as well as those defined by the user)
-    reorder task execution. During this reordering, Miou can collect the system
-    events that have just occurred. The objective is to do this as often as
-    possible!
+    Most of the Miou's effects reorder task execution. During this reordering,
+    Miou can collect the system events that have just occurred. The objective is
+    to do this as often as possible!
 
     {4 Performance and events.}
 


### PR DESCRIPTION
Since #124, some of our effects are "free" in the sense that they don't do a yield. It's necessary to ensure some assumptions about Miou.Ownership and finalizers (and their atomicity regarding Miou). Now, we have some internal effects (such as Self) which don't reschedule tasks. We must re-explain so how Miou reacts with effects. Also, since #126, user's defined effects don't yield. It permits for us to open a bridge with some others schedulers locally to tasks (or globally by inheritance of handlers). The rest of the model of Miou is kept.