### PR TITLE
Being able to control when we want to observe events.

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -86,17 +86,26 @@
 (rule
  (targets miou_unix.poll.ml)
  (deps miou_unix.sleep.ml.in miou_unix.poll.ml.in miou_unix.common.ml.in)
- (action (with-stdout-to %{targets} (run %{exe:conf/concat.exe} %{deps}))))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run %{exe:conf/concat.exe} %{deps}))))
 
 (rule
  (targets miou_unix.select.ml)
  (deps miou_unix.sleep.ml.in miou_unix.select.ml.in miou_unix.common.ml.in)
- (action (with-stdout-to %{targets} (run %{exe:conf/concat.exe} %{deps}))))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run %{exe:conf/concat.exe} %{deps}))))
 
 (rule
  (targets miou_unix.epoll.ml)
  (deps miou_unix.sleep.ml.in miou_unix.epoll.ml.in miou_unix.common.ml.in)
- (action (with-stdout-to %{targets} (run %{exe:conf/concat.exe} %{deps}))))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run %{exe:conf/concat.exe} %{deps}))))
 
 (rule
  (targets miou_poll_config.ml miou_ppoll.h)

--- a/lib/miou.ml
+++ b/lib/miou.ml
@@ -269,11 +269,13 @@ type domain = {
     uid: Domain_uid.t
   ; tasks: Run_queue.t
   ; quanta: int
+  ; budget: int
   ; g: Random.State.t
   ; events: events
   ; cancelled_syscalls: Syscall_uid.t Queue.t
   ; syscalls: int Atomic.t
   ; hooks: (unit -> unit) Miou_sequence.t
+  ; mutable credit: int
 }
 
 type 'r continuation = (State.error option, 'r) State.continuation
@@ -530,17 +532,19 @@ let dom0_interrupt = Atomic.make ignore
 module Domain = struct
   module Uid = Domain_uid
 
-  let create ?(quanta = 1) ~events g uid =
+  let create ?(quanta = 1) ?poll:(budget = 0) ~events g uid =
     let tasks = Run_queue.create () in
     {
       uid
     ; tasks
     ; quanta
+    ; budget
     ; g
     ; events= events uid
     ; syscalls= Atomic.make 0
     ; cancelled_syscalls= Queue.create ()
     ; hooks= Miou_sequence.create ()
+    ; credit= 0
     }
 
   (* NOTE(dinosaure): as far as [event.interrupt] is domain-safe (which should
@@ -1074,7 +1078,8 @@ module Domain = struct
     else wakeup_dom0_if_needed pool;
     let block = Run_queue.is_empty domain.tasks in
     let has_cancelled = Queue.is_empty domain.cancelled_syscalls = false in
-    if block || has_cancelled then begin
+    if block || has_cancelled || domain.credit <= 0 then begin
+      domain.credit <- domain.budget;
       let cancelled =
         if has_cancelled then
           Queue.(to_list (transfer domain.cancelled_syscalls))
@@ -1083,6 +1088,7 @@ module Domain = struct
       let syscalls = domain.events.select ~block cancelled in
       List.iter (signal_system_events domain) syscalls
     end
+    else domain.credit <- domain.credit - 1
 
   let system_events_suspended domain =
     (* NOTE(dinosaure): we consider a signal as a system event which can
@@ -1907,12 +1913,23 @@ end
 
 let quanta =
   match Sys.getenv_opt "MIOU_QUANTA" with
-  | Some str -> ( try int_of_string str with _ -> 1)
+  | Some str ->
+      let n = try int_of_string str with _ -> 1 in
+      Int.max 1 n
   | None -> 1
+
+let poll =
+  match Sys.getenv_opt "MIOU_POLL" with
+  | Some str ->
+      let n = try int_of_string str with _ -> 0 in
+      Int.max 0 n
+  | None -> 0
 
 let domains =
   match Sys.getenv_opt "MIOU_DOMAINS" with
-  | Some str -> ( try int_of_string str with _ -> Pool.number_of_domains ())
+  | Some str ->
+      let n = try int_of_string str with _ -> Pool.number_of_domains () in
+      Int.max 0 n
   | None -> Pool.number_of_domains ()
 
 let error_select =
@@ -1942,11 +1959,11 @@ let sys_signal signal = function
       in
       Sys.signal signal (Signal_handle fn)
 
-let run ?(quanta = quanta) ?(g = Random.State.make_self_init ())
+let run ?(quanta = quanta) ?(poll = poll) ?(g = Random.State.make_self_init ())
     ?(domains = domains) ?(events = Fun.const dummy_events) ?handler fn =
   Promise_uid.reset ();
   let dom0 = Domain_uid.of_int 0 in
-  let dom0 = Domain.create ~quanta ~events g dom0 in
+  let dom0 = Domain.create ~quanta ~poll ~events g dom0 in
   (* NOTE(dinosaure): set [dom0_interrupt] used by [sys_signal] to be able to
      wake-up [dom0] if it is on the sleeping mode and when we retrieve a signal
      on another domain. *)

--- a/lib/miou.mli
+++ b/lib/miou.mli
@@ -1263,6 +1263,7 @@ type events = {
 
 val run :
      ?quanta:int
+  -> ?poll:int
   -> ?g:Random.State.t
   -> ?domains:int
   -> ?events:(Domain.Uid.t -> events)

--- a/lib/miou.mli
+++ b/lib/miou.mli
@@ -121,6 +121,21 @@
     function. We recommend using [Domain.recommended_domain_count () - 1]
     domains.
 
+    Miou provides an environment variable, [MIOU_DOMAINS], which can be used to
+    specify the number of domains that a Miou application can allocate. For
+    example, [MIOU_DOMAINS=3] allocates 4 domains (3 domains plus dom0).
+    [MIOU_DOMAINS=0] ensures that no domains are allocated (and therefore only
+    [Miou.async] is available). For some applications, it may be useful to have
+    a function such as [call_or_async] in order to test your application with or
+    without parallelism:
+
+    {[
+    let call_or_async ?give ?orphans ?handler fn =
+      if Miou.Domain.available () <= 0 then
+        Miou.async ?give ?orphans ?handler fn
+      else Miou.call ?give ?orphans ?handler fn
+    ]}
+
     {2 Design.}
 
     After this brief introduction to the basics of Miou (i.e. the use of effects
@@ -217,13 +232,61 @@
 
     If we want to be in the best position to manage system events, we need to
     {i increase} the points of cooperation that the fibers can emit. This is how
-    Miou came up with a fundamental rule: {b an effect yields}.
+    Miou came up with a fundamental rule: {b an effect yields}. Most of the
+    Miou's effects reorder task execution. During this reordering, Miou can
+    collect the system events that have just occurred. The objective is to do
+    this as often as possible!
 
-    Most of the Miou's effects reorder task execution. During this reordering,
-    Miou can collect the system events that have just occurred. The objective is
-    to do this as often as possible!
+    More specifically, Miou introduces a new metric: {e the quanta}. A quanta is
+    the execution of a task between two suspensions of that task: we say that a
+    quanta is consumed when a task {i progresses} up to its suspension. This
+    suspension occurs when a [Effect.perform] is called, because
+    {e an effect yields}. In other words, a quanta represents the execution of a
+    task up to an [Effect.perform].
 
-    {4 Performance and events.}
+    Not every effect costs a quanta: those Miou considers {i free} (pure queries
+    on the scheduler's state, which never suspend the task) are performed
+    without consuming anything, whatever [MIOU_QUANTA] is set to. For instance,
+    {!val:Miou.Domain.available} is a {i free} effect and does not re-schedule
+    tasks:
+
+    {[
+      # Miou.run @@ fun () ->
+        let prm = Miou.async @@ fun () -> Miou.Domain.available () in
+        print_endline "> foo";
+        let a = Miou.Domain.available () in
+        print_endline "> bar";
+        assert (a = Miou.await_exn prm)
+      > foo
+      > bar
+      - : unit = ()
+    ]}
+
+    In certain contexts (particularly with regard to benchmarks), it may be
+    useful to consume more than one [Effect.perform] before the task is
+    suspended: and thus to consume more than one quanta.
+
+    Miou provides an environment variable [MIOU_QUANTA] which allows you to
+    specify the number of quanta that Miou permits in the execution of a task
+    before it is suspended (in other words, how many [Effect.perform] operations
+    are permitted before the task is suspended).
+
+    For example, [MIOU_QUANTA=64] can make the execution of multiple tasks
+    fairer, whereas [MIOU_QUANTA=1] makes the execution of effects fairer. The
+    issue is that a task generally executes several effects: fairness regarding
+    effects does not therefore imply fairness regarding tasks! [MIOU_QUANTA]
+    allows you to approximate this fairness at the task level, depending on your
+    application.
+
+    {b NOTE}: raising the quanta changes the order in which tasks run, and that
+    order is itself documented. The second example given for {!val:yield} prints
+    [Hello] then [World], because the child runs before the parent resumes; with
+    [MIOU_QUANTA=64] the very same program prints [World] then [Hello].
+    Generally speaking, it is strongly advised not to rely on the order in which
+    tasks are executed (for all schedulers). It should therefore be noted that
+    [MIOU_QUANTA] has a real impact on the order in which tasks are executed.
+
+    {4:performance Performance and events.}
 
     At this point, we need to make clear to our future users a crucial choice we
     made for Miou: we prefer a scheduler that's available for system events,
@@ -234,6 +297,32 @@
     do nothing but calculations, the latter will be {i "polluted"} by these
     unnecessary points of cooperation. So, by default, Miou is {b less}
     efficient than other schedulers.
+
+    The aim of ensuring an application’s availability means that it should call
+    [events.select] frequently. The problem is that this function generally
+    corresponds to a {i syscall} ([select(3)], [poll(2)] or [epoll(7)]) which
+    can be time-consuming and degrade the performance of a Miou application. By
+    default, [events.select] is called {e each} time a task has been executed
+    (once per task, whatever [MIOU_QUANTA] allowed that task to do in the
+    meantime). The two variables are orthogonal: [MIOU_QUANTA] bounds how far a
+    task goes before it is rescheduled, [MIOU_POLL] how many tasks run between
+    two readiness checks. It is also possible therefor to specify a {i budget}
+    and allow several tasks to run before calling [events.select] (which reduces
+    availability).
+
+    This is why there is an environment variable [MIOU_POLL] which allows you to
+    specify this budget, i.e. how many tasks should be executed before events
+    are monitored. In some cases, it is preferable to have lower availability
+    (for example, with [MIOU_POLL=32]) in order to increase the throughput of a
+    service (such as an HTTP service).
+
+    Two things are deliberately kept, whatever the budget is. A domain whose
+    run-queue is {b empty} always calls [events.select], and blocks in it: a
+    domain with nothing else to do is never delayed, so the budget only ever
+    applies when there is other work to run right now. And a cancellation always
+    forces the call, since a cancelled syscall must leave the poll set promptly.
+    What the budget trades is therefore narrower than it looks: a {i busy}
+    domain notices new I/O within [n] tasks instead of immediately.
 
     {3 Miou and the system.}
 
@@ -1118,7 +1207,10 @@ val yield : unit -> unit
       Hello
       World
       - : unit = ()
-    ]} *)
+    ]}
+
+    {b NOTE}: this ordering is that of the default [MIOU_QUANTA=1]. Raising the
+    quanta reorders these two examples; see {!section:performance} above. *)
 
 module Hook : sig
   type t
@@ -1293,7 +1385,7 @@ val protect :
     case of a cancellation, [protect] invokes [on_cancellation ()] and then
     [finally ()] (with [cancelled:true]).
 
-    If [finally] raises an exception, then the exception {!Fun.Finally_raises}
+    If [finally] raises an exception, then the exception {!Fun.Finally_raised}
     is raised instead. If [on_cancellation] raises an exception, then the
     "uncatchable" exception [On_cancellation_raised] is raised instead.
 

--- a/lib/miou_unix.epoll.ml.in
+++ b/lib/miou_unix.epoll.ml.in
@@ -38,28 +38,31 @@ module File_descrs = struct
 end
 
 (* NOTE(dinosaure): [epoll] has a rather unusual instruction that is of
-   interest to us here: [EPOLLONESHOT]. The idea is to let the kernel remove a
+   interest to us here: [EPOLLONESHOT]. The idea is to let the kernel disables a
    file descriptor from [epoll] if it has been signalled (whether IN or OUT, it
-   doesn’t matter). We will therefore take advantage of this feature so as not
-   to have to call [Epoll.del] systematically when we want to stop monitoring a
-   [file_descr] (after having signalled it).
+   doesn’t matter). Note that the registration of the file-descriptor is kept
+   but no further event is reported until we {i re-arm} it. We will therefore
+   take advantage of this feature so as not to have to call [Epoll.del]
+   systematically when we want to stop monitoring a [file_descr] (after having
+   signalled it).
 
    We therefore maintain an [armed] table for the current domain, which should
    mirror what the kernel observes regarding file descriptors. This flag table
    is of size [_SC_OPEN_MAX] (we should not have a [file_descr]/[int] larger
    than this number). Based on this table and depending on what we wish to
    monitor, we always add [EPOLLONESHOT]. Finally, when the user considers that
-   their [file_descr] should be released (using [Miou_unix]), we ‘forget’ its
+   their [file_descr] should be released (using [Miou_unix]), we {i forget} its
    flag in [armed] so that [armed] is always synchronised with what the kernel
    observes.
 
-   Finally, there is a final table, [drained], which allows us to optimise a
-   very specific scenario: this is when we want confirmation that there is
-   nothing left to read (that [Unix.read] returns [0]) without actually calling
-   [Unix.read], which would probably return [EAGAIN] whilst waiting for the
-   client-side closure. This final optimisation involves an [unsafe_read] that
-   is slightly different from what [miou_unix.{select,poll}.ml.in] provides -
-   which is why it is not included in [miou_unix.common.ml.in]). *)
+   Finally, there is a final table, [drained], which notifies us that the
+   kernel's buffer of the given socket is empty. A next [Unix.read] call will
+   terminate directly with a [EAGAIN] and we would like to save us from such
+   useless syscall. So, if [is_drained fd], we fallbacks directly to a
+   [blocking_read] without a confirmation from the kernel (via [Unix.read]) that
+   its buffer is actually empty. We are sure that such buffer is empty because
+   the last [Unix.read] gives to us few bytes ([> 0]) but not enough to fill
+   our buffer ([< len]). *)
 
 type domain = {
     readers: File_descrs.t

--- a/lib/miou_unix.epoll.ml.in
+++ b/lib/miou_unix.epoll.ml.in
@@ -119,7 +119,8 @@ let arm domain fd =
 
 let forget domain fd =
   let idx = int_of_file_descr fd in
-  if idx < Bytes.length domain.armed then Bytes.unsafe_set domain.armed idx '\000';
+  if idx < Bytes.length domain.armed then
+    Bytes.unsafe_set domain.armed idx '\000';
   if idx < Bytes.length domain.drained then
     Bytes.unsafe_set domain.drained idx '\000'
 
@@ -341,4 +342,5 @@ let events uid =
   let finaliser () = Unix.close ic; Unix.close oc in
   { Miou.interrupt= interrupt oc; select; finaliser }
 
-let run ?g ?domains ?handler fn = Miou.run ~events ?g ?domains ?handler fn
+let run ?quanta ?poll ?g ?domains ?handler fn =
+  Miou.run ?quanta ?poll ~events ?g ?domains ?handler fn

--- a/lib/miou_unix.mli
+++ b/lib/miou_unix.mli
@@ -286,7 +286,9 @@ val sleep : float -> unit
 (** {3 First entry point.} *)
 
 val run :
-     ?g:Random.State.t
+     ?quanta:int
+  -> ?poll:int
+  -> ?g:Random.State.t
   -> ?domains:int
   -> ?handler:Miou.Handler.t
   -> (unit -> 'a)

--- a/lib/miou_unix.mli
+++ b/lib/miou_unix.mli
@@ -58,7 +58,7 @@
     Here are some explanations of the code above.
     + There is no reference to the [Miou_unix] module (although there are
       references to [Unix]). As we said, [Miou_unix] only manages
-      {!type:file-descr}. In the code above, it is more about signal management.
+      {!type:file_descr}. In the code above, it is more about signal management.
     + First, a program is launched with [Unix.create_process] and a {i handler}
       is installed on the [SIGCHLD] signal. Please refer to the
       {!val:Miou.sys_signal} documentation.
@@ -247,7 +247,7 @@ val recvfrom :
     actual number of characters received, between 0 and [len] (inclusive) and
     the peer which sent these bytes.
 
-    @raise Unix.Unixerror
+    @raise Unix.Unix_error
       raised by the system call {!val:unix.recvfrom}. The function handles
       {!constructor:Unix.EINTR}, {!constructor:Unix.EAGAIN} and
       {!constructor:Unix.EWOULDBLOCK} exceptions and redo the system call.

--- a/lib/miou_unix.poll.ml.in
+++ b/lib/miou_unix.poll.ml.in
@@ -272,4 +272,5 @@ let events uid =
   let finaliser () = Unix.close ic; Unix.close oc in
   { Miou.interrupt= interrupt oc; select; finaliser }
 
-let run ?g ?domains ?handler fn = Miou.run ~events ?g ?domains ?handler fn
+let run ?quanta ?poll ?g ?domains ?handler fn =
+  Miou.run ?quanta ?poll ~events ?g ?domains ?handler fn

--- a/lib/miou_unix.select.ml.in
+++ b/lib/miou_unix.select.ml.in
@@ -234,4 +234,5 @@ let events domain =
   let finaliser () = Unix.close ic; Unix.close oc in
   { Miou.interrupt= interrupt oc; select; finaliser }
 
-let run ?g ?domains ?handler fn = Miou.run ~events ?g ?domains ?handler fn
+let run ?quanta ?poll ?g ?domains ?handler fn =
+  Miou.run ?quanta ?poll ~events ?g ?domains ?handler fn


### PR DESCRIPTION
For reasons of availability, events are observed as soon as there are no other tasks to be performed at that moment. This ensures that an application always remains responsive when new events occur, even whilst Miou is attempting to execute tasks. However, this observation can come with a fairly significant cost.

We now offer the option to monitor less frequently and allow [MIOU_POLL] iterations (for task execution) before calling the [events.select] function: in this way, you can fine-tune a Miou application to achieve better throughput (particularly with regard to HTTP).

For example, we are able to handle 686k Req/s with MIOU_POLL=8, MIOU_QUANTA=64 and MIOU_DOMAINS=7 (+dom0) when handling 64 clients across 12 threads, whereas in the same scenario we previously achieved 287k Req/s (the difference is also due to the use of [epoll(7)]).